### PR TITLE
Add progress bar and fix preview persistence

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -463,7 +463,12 @@
       <button id="quizAllBtn">🎲 Random Quiz</button>
     </div>
 
-    <div id="progressStatus" style="display:none; margin:8px 24px; font-weight:bold;"></div>
+    <div id="progressStatus" style="display:none; margin:8px 24px;">
+      <div id="progressText" style="font-weight:bold;"></div>
+      <div id="progressBarContainer" style="height:8px; background:#ccc; border-radius:4px; margin-top:4px;">
+        <div id="progressBar" style="height:100%; width:0; background:#1abc9c; border-radius:4px;"></div>
+      </div>
+    </div>
 
     <div id="editorArea">
       <div id="toolbar">
@@ -539,14 +544,18 @@
       const quizProgress = {};  // per-folder random quiz progress
 
       function updateProgressIndicator() {
-        const stat = document.getElementById('progressStatus');
+        const cont = document.getElementById('progressStatus');
+        const text = document.getElementById('progressText');
+        const bar  = document.getElementById('progressBar');
         const prog = quizProgress[currentFolder];
         if (!prog || !isQuizMode || quizOrder.length <= 1) {
-          stat.style.display = 'none';
+          cont.style.display = 'none';
           return;
         }
-        stat.textContent = `Progress: ${prog.completed.size} / ${prog.total}`;
-        stat.style.display = 'block';
+        cont.style.display = 'block';
+        text.textContent = `Progress: ${prog.completed.size} / ${prog.total}`;
+        const percent = prog.total ? (prog.completed.size / prog.total) * 100 : 0;
+        bar.style.width = percent + '%';
       }
 
       function questionCompleted() {
@@ -1933,7 +1942,10 @@
         isQuizMode = false;
         enterEdit();
         // Reload the current section in edit mode if one is selected
-        if (currentSection !== null) loadSection();
+        if (currentSection !== null) {
+          loadSection();
+          previewSection();
+        }
       };
 
       function enterEdit(){


### PR DESCRIPTION
## Summary
- show a visual progress bar when quizzing
- ensure edit mode preview refreshes after switching from quiz mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68644ffe950483238e8dece50960b17d