### PR TITLE
Fix quiz blanks display for new questions

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2026,8 +2026,6 @@
         }
         const raw = rawText.toLowerCase();
 
-        const raw = (sec.rawText || '').toLowerCase();
-
         const validEntries = (hiddenEntries || []).filter(({ word, occ }) => {
           const allMatches = [...raw.matchAll(new RegExp(`\\b${word.toLowerCase()}\\b`, 'g'))];
           const isValid = occ <= allMatches.length;
@@ -2120,7 +2118,9 @@
           quizContent.innerHTML = '';
           quizContent.appendChild(titleElem);
           quizContent.innerHTML += sec.rawHtml || sec.rawText || '';
-          wrapQuizBlanks(quizContent, sec.hidden || []);
+          const tokensArr = (sec.rawText || '').split(/(\s+)/);
+          const hiddenEntries = getHiddenEntries(sec, tokensArr);
+          wrapQuizBlanks(quizContent, hiddenEntries);
           // --- Improved blank sizing using text width measurement ---
           // Create a hidden span for measuring text width
           const measure = document.createElement('span');


### PR DESCRIPTION
## Summary
- remove duplicate `raw` declaration
- compute `hiddenEntries` before wrapping blanks in quiz mode

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68645a96d0ec8323978d568481dfd1d0