### PR TITLE
Fix blank detection in quiz mode

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2018,15 +2018,15 @@
         // Filter out invalid hidden entries (word/occ not present in text)
         const sec = data.folders[currentFolder].sections[currentSection];
 
-        let rawText = sec.rawText || '';
-        if (!rawText && sec.rawHtml) {
+        let rawText = '';
+        if (sec.rawHtml) {
           const tmp = document.createElement('div');
           tmp.innerHTML = sec.rawHtml;
           rawText = tmp.innerText || '';
+        } else {
+          rawText = sec.rawText || '';
         }
         const raw = rawText.toLowerCase();
-
-        const raw = (sec.rawText || '').toLowerCase();
 
         const validEntries = (hiddenEntries || []).filter(({ word, occ }) => {
           const allMatches = [...raw.matchAll(new RegExp(`\\b${word.toLowerCase()}\\b`, 'g'))];


### PR DESCRIPTION
## Summary
- ensure quiz script parses by removing duplicate variable declaration
- build raw text from HTML when checking quiz blanks

## Testing
- `node - <<'EOF'
const fs=require('fs');
const html=fs.readFileSync('QuizMaker.html','utf8');
const scripts=html.match(/<script>([\s\S]*?)<\/script>/g);
for(let i=0;i<scripts.length;i++){try{new Function(scripts[i].replace(/<script>|<\/script>/g,''));console.log('Script',i,'ok');}catch(e){console.error('Script',i,'error',e.message);}}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68645a96d0ec8323978d568481dfd1d0