### PR TITLE
Fix blank detection in quiz mode

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2018,18 +2018,25 @@
         // Filter out invalid hidden entries (word/occ not present in text)
         const sec = data.folders[currentFolder].sections[currentSection];
 
-        let rawText = sec.rawText || '';
-        if (!rawText && sec.rawHtml) {
+        let rawText = '';
+        if (sec.rawHtml) {
           const tmp = document.createElement('div');
           tmp.innerHTML = sec.rawHtml;
           rawText = tmp.innerText || '';
+        } else {
+          rawText = sec.rawText || '';
         }
-        const raw = rawText.toLowerCase();
-
-        const raw = (sec.rawText || '').toLowerCase();
+        const rawLower = rawText.toLowerCase();
 
         const validEntries = (hiddenEntries || []).filter(({ word, occ }) => {
-          const allMatches = [...raw.matchAll(new RegExp(`\\b${word.toLowerCase()}\\b`, 'g'))];
+          const wordLower = word.toLowerCase();
+          const escaped = wordLower.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+          const startsWordChar = /\w/.test(wordLower[0]);
+          const endsWordChar   = /\w/.test(wordLower[wordLower.length - 1]);
+          let pattern = escaped;
+          if (startsWordChar) pattern = '\\b' + pattern;
+          if (endsWordChar)   pattern = pattern + '\\b';
+          const allMatches = [...rawLower.matchAll(new RegExp(pattern, 'g'))];
           const isValid = occ <= allMatches.length;
           if (!isValid && sec.alts) {
             delete sec.alts[`${word}_${occ}`];


### PR DESCRIPTION
## Summary
- ensure quiz script parses by removing duplicate variable declaration
- build raw text from HTML when checking quiz blanks
- improve regex used to validate blanks so punctuation doesn't cause problems

## Testing
- `node - <<'EOF'
const fs=require('fs');
const html=fs.readFileSync('QuizMaker.html','utf8');
const scripts=html.match(/<script>([\s\S]*?)<\/script>/g);
for(let i=0;i<scripts.length;i++){try{new Function(scripts[i].replace(/<script>|<\/script>/g,''));console.log('Script',i,'ok');}catch(e){console.error('Script',i,'error',e.message);}}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68645a96d0ec8323978d568481dfd1d0