### PR TITLE
Add fallback to GitHub hosted quiz data

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -564,6 +564,7 @@
         return inputs.every(inp => inp.classList.contains('correct'));
       }
       // ----- Load persistent data, with static fallback -----
+      const GITHUB_JSON_URL = 'https://raw.githubusercontent.com/Ethan11San/Ethan11San.github.io/main/quizData.json';
       let data;
       let staticMode = false;
       try {
@@ -575,14 +576,22 @@
           throw new Error('API response not OK: ' + resp.status);
         }
       } catch (apiErr) {
-        console.warn('API unavailable, falling back to static quizData.json', apiErr);
+        console.warn('API unavailable, falling back to quizData.json', apiErr);
         staticMode = true;
         try {
           const resp2 = await fetch('./quizData.json', { cache: 'no-store' });
-          data = resp2.ok ? await resp2.json() : { folders: [] };
+          if (!resp2.ok) throw new Error('Static file response not OK');
+          data = await resp2.json();
         } catch (staticErr) {
-          console.error('Error loading static quizData.json:', staticErr);
-          data = { folders: [] };
+          console.warn('Local quizData.json unavailable, attempting GitHub raw', staticErr);
+          try {
+            const resp3 = await fetch(GITHUB_JSON_URL, { cache: 'no-store' });
+            if (!resp3.ok) throw new Error('GitHub raw response not OK');
+            data = await resp3.json();
+          } catch (githubErr) {
+            console.error('Error loading quiz data from GitHub:', githubErr);
+            data = { folders: [] };
+          }
         }
       }
       // Initialize currentFolder/Section based on loaded data...

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Ethan11San.github.io
-Testing123
+This repository contains the `QuizMaker` web app and its data file `quizData.json`.
+
+When loaded, `QuizMaker.html` will attempt to fetch quiz data from a local API
+(`http://localhost:5001/api/quizData`). If that fails, it falls back to the
+bundled `quizData.json`. If the JSON file cannot be loaded locally (for example
+when opening the page directly from the file system), a final fallback fetches
+`quizData.json` from the GitHub repository.


### PR DESCRIPTION
## Summary
- add fallback to fetch quiz data from GitHub raw URL
- document new data loading behavior in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68649eb01300832386535aae0e5e91ab