### PR TITLE
Fix quiz mode content overwrite

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1978,7 +1978,7 @@
         updateProgressIndicator();
       }
       function enterQuiz(){
-          syncCurrentSection();
+          if(!isQuizMode) syncCurrentSection();
         if (currentFolder === null) {
           alert('Select a folder first');
           return;
@@ -1991,7 +1991,7 @@
 
       // Starts a random-order quiz across all sections in the current folder
       function enterRandomQuiz() {
-          syncCurrentSection();
+          if(!isQuizMode) syncCurrentSection();
         if (currentFolder === null) {
           alert('Select a folder first');
           return;
@@ -2029,7 +2029,7 @@
         showQuiz();
       }
       quizModeBtn.onclick = () => {
-        syncCurrentSection();
+        if(!isQuizMode) syncCurrentSection();
         isQuizMode = true;
         // Show quiz for the currently selected section
         if (currentSection !== null) {


### PR DESCRIPTION
## Summary
- avoid overwriting current question when starting a quiz

## Testing
- `grep -n 'if(!isQuizMode) syncCurrentSection' QuizMaker.html`

------
https://chatgpt.com/codex/tasks/task_e_686fcb0a7d208323b042dd72afd4f8eb