### PR TITLE
Fix random quiz resume position

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2230,12 +2230,14 @@
         });
       }
 
-      function showQuiz() {
-        // Advance to the correct section
-        currentSection = quizOrder[quizPos];
-        const prog = quizProgress[currentFolder];
-        if (prog) prog.pos = quizPos;
-        saveProgress();
+        function showQuiz() {
+          // Advance to the correct section
+          currentSection = quizOrder[quizPos];
+          const prog = quizProgress[currentFolder];
+          if (prog && quizOrder.length > 1) {
+            prog.pos = quizPos;
+            saveProgress();
+          }
         // Now load that section’s data
         let sec = data.folders[currentFolder].sections[currentSection];
         updateProgressIndicator();


### PR DESCRIPTION
## Summary
- preserve progress in `Random Quiz` mode when exiting

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687089f68aa88323aeb50487fd27f897