### PR TITLE
Improve definition editing UX

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1110,6 +1110,7 @@
         // Hide all main editors
         if (editorDiv) editorDiv.style.display = previewDiv.style.display = labelEditor.style.display = 'none';
         altContainer.style.display = 'none';
+        altContainer.innerHTML = '';
 
         if (sec.type === 'acronym') {
           labelEditor.style.display = 'block';
@@ -1210,6 +1211,20 @@
             h4.style.fontSize = '1.1rem';
             h4.style.flex = '1';
             row.appendChild(h4);
+
+            const toggleLbl = document.createElement('label');
+            toggleLbl.style.fontSize = '0.9rem';
+            toggleLbl.style.marginRight = '8px';
+            toggleLbl.textContent = 'Hide until solved ';
+            const toggle = document.createElement('input');
+            toggle.type = 'checkbox';
+            toggle.checked = !!def.hideUntilSolved;
+            toggle.onchange = () => {
+              def.hideUntilSolved = toggle.checked;
+              saveData();
+            };
+            toggleLbl.appendChild(toggle);
+            row.appendChild(toggleLbl);
             const del = document.createElement('span');
             del.textContent = '✖';
             del.style.cursor = 'pointer';
@@ -1247,13 +1262,20 @@
               saveData();
               buildDefinitionPreview(def, prevDiv, altDiv);
             });
-            adjustDefHeight();
             wrapper.appendChild(ta);
+            adjustDefHeight();
             wrapper.appendChild(prevDiv);
             wrapper.appendChild(altDiv);
             buildDefinitionPreview(def, prevDiv, altDiv);
             defContainer.appendChild(wrapper);
           });
+          // Ensure textareas fit existing text after load
+          setTimeout(() => {
+            defContainer.querySelectorAll('textarea').forEach(t => {
+              t.style.height = 'auto';
+              t.style.height = t.scrollHeight + 'px';
+            });
+          }, 0);
           // (rest unchanged, image/label/arrow logic)
           const img = document.getElementById('labelImg');
           const overlay = document.getElementById('labelOverlay');
@@ -1411,7 +1433,8 @@
                 labelText: lbl.text,
                 rawText: '',
                 hidden: [],
-                alts: {}
+                alts: {},
+                hideUntilSolved: false
               });
               saveData();
               isAddingDefinition = false;
@@ -2056,6 +2079,8 @@
       function enterEdit(){
         editorArea.style.display = 'block';
         quizArea.style.display = 'none';
+        altContainer.style.display = 'none';
+        altContainer.innerHTML = '';
         renderSections(lastSectionOrder);
         updateProgressIndicator();
       }
@@ -2509,6 +2534,7 @@
                 if (entry && !entry.revealed) {
                   entry.el.textContent = (entry.idx + 1) + '. ' + lbl.text + ': ';
                   entry.revealed = true;
+                  if (entry.hide) entry.para.style.display = '';
                 }
               } else {
                 // keep feedback colours while user is typing
@@ -2563,11 +2589,12 @@
               // Prefix each definition with its number – label name stays hidden until solved
               const para = document.createElement('p');
               para.style.marginBottom = '12px';
+              if (def.hideUntilSolved) para.style.display = 'none';
               const title = document.createElement('strong');
               title.textContent = (dIndex + 1) + '. ';
               para.appendChild(title);
               // Register this definition's title for reveal
-              titleMap[def.labelText] = { el: title, idx: dIndex };
+              titleMap[def.labelText] = { el: title, idx: dIndex, para, hide:def.hideUntilSolved, revealed:false };
               const tokens = (def.rawText || '').split(/(\s+)/);
               const hiddenEntries = getHiddenEntries(def, tokens);
               let counts = {};


### PR DESCRIPTION
## Summary
- resize existing definition textareas when the section loads
- hide alt-answer container immediately when entering edit mode

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876c3d33664832395998262772dafb7