### PR TITLE
Add keyboard shortcuts for quiz navigation

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2868,6 +2868,19 @@
         }
       };
 
+      // --- Keyboard shortcuts for quiz navigation and hints ---
+      document.addEventListener('keydown', e => {
+        if (!isQuizMode) return;                // only active in quiz modes
+        if (e.metaKey && e.key === 'Enter') {   // Command + Enter => next question
+          e.preventDefault();
+          nextBtn.click();
+        }
+        if (e.metaKey && (e.key === 'h' || e.key === 'H')) {  // Command + H => hint
+          e.preventDefault();
+          hintBtn.click();
+        }
+      });
+
     } catch (err) {
       console.error(err);
       alert('Unhandled error: ' + err.message);


### PR DESCRIPTION
## Summary
- add Command+Enter and Command+H shortcuts when in quiz modes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68787d34bcb083239585bb6ab11a2dfb