### PR TITLE
Fix popup word click

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2422,7 +2422,9 @@
               }
             });
           } else if (node.nodeType === Node.ELEMENT_NODE) {
-            if (node.tagName === 'UL') {
+            if (node.classList && node.classList.contains('popup-word')) {
+              previewDiv.appendChild(node.cloneNode(true));
+            } else if (node.tagName === 'UL') {
               // Flatten each list item into its own preview line with a bullet
               node.childNodes.forEach(liNode => {
                 if (liNode.nodeType !== Node.ELEMENT_NODE || liNode.tagName !== 'LI') return;
@@ -2491,6 +2493,8 @@
                       para.appendChild(span);
                     }
                   });
+                } else if (child.nodeType === Node.ELEMENT_NODE && child.classList && child.classList.contains('popup-word')) {
+                  para.appendChild(child.cloneNode(true));
                 } else if (child.nodeType === Node.ELEMENT_NODE && child.tagName === 'BR') {
                   para.appendChild(document.createElement('br'));
                 } else if (child.nodeType === Node.ELEMENT_NODE) {


### PR DESCRIPTION
## Summary
- preserve `popup-word` spans when rendering preview so images are clickable in edit and quiz views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f18d18cf88323ae49ffbd68196b83