### PR TITLE
Improve image paste and zoom

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1637,10 +1637,9 @@
         if (!waitingForImagePaste) return;
         if (currentFolder === null) return;
         const items = e.clipboardData && e.clipboardData.items;
-        if (!items) return;
-        for (let item of items) {
-          if (item.type.indexOf('image') !== -1) {
-            const blob = item.getAsFile();
+
+        async function handleBlob(blob) {
+          return new Promise(resolve => {
             const reader = new FileReader();
             reader.onload = async () => {
               const sec = data.folders[currentFolder].sections[currentSection];
@@ -1655,11 +1654,41 @@
               renderSections(lastSectionOrder);
               enterEdit();
               loadSection();
+              waitingForImagePaste = null;
+              resolve(true);
             };
             reader.readAsDataURL(blob);
-            waitingForImagePaste = null;
-            e.preventDefault();
-            break;
+          });
+        }
+
+        let found = false;
+        if (items) {
+          for (let item of items) {
+            if (item.type.indexOf('image') !== -1) {
+              const blob = item.getAsFile();
+              await handleBlob(blob);
+              found = true;
+              e.preventDefault();
+              break;
+            }
+          }
+        }
+
+        if (!found) {
+          try {
+            const clipItems = await navigator.clipboard.read();
+            for (const item of clipItems) {
+              const type = item.types.find(t => t.startsWith('image/'));
+              if (type) {
+                const blob = await item.getType(type);
+                await handleBlob(blob);
+                found = true;
+                e.preventDefault();
+                break;
+              }
+            }
+          } catch (err) {
+            console.warn('Clipboard read failed', err);
           }
         }
       });
@@ -3575,6 +3604,19 @@
         img.src = target.dataset.img;
         img.style.maxWidth = '200px';
         img.style.maxHeight = '200px';
+        img.dataset.zoomed = '0';
+        img.addEventListener('dblclick', evt2 => {
+          evt2.stopPropagation();
+          if (img.dataset.zoomed === '1') {
+            img.style.maxWidth = '200px';
+            img.style.maxHeight = '200px';
+            img.dataset.zoomed = '0';
+          } else {
+            img.style.maxWidth = '80vw';
+            img.style.maxHeight = '80vh';
+            img.dataset.zoomed = '1';
+          }
+        });
         popup.appendChild(img);
         popup.addEventListener('click', e => e.stopPropagation());
         document.body.appendChild(popup);


### PR DESCRIPTION
## Summary
- handle clipboard image paste more robustly
- allow double-click zoom of popup images

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_688289fd4ea483239d7efdf0d2cda532