### PR TITLE
Fix color picker access

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1393,7 +1393,7 @@
             }
           };
           li.ondblclick = evt => {
-            if (evt.metaKey) {
+            if (evt.metaKey || evt.ctrlKey) {
               const colorInput = document.createElement('input');
               colorInput.type = 'color';
               colorInput.value = f.color || '#1abc9c';

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ When loaded, `QuizMaker.html` will attempt to fetch quiz data from a local API
 bundled `quizData.json`. If the JSON file cannot be loaded locally (for example
 when opening the page directly from the file system), a final fallback fetches
 `quizData.json` from the GitHub repository.
+
+## Changing folder colors
+
+In the **Folders** list, you can pick a custom color for a folder by holding
+either **Command** (macOS) or **Control** (Windows/Linux) while double-clicking
+the folder name. This opens a color picker dialog.


### PR DESCRIPTION
## Summary
- open folder color picker on meta or control double-click
- document how to access the folder color picker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68830cb704908323a5b16c4940662ef4