### PR TITLE
Fix mobile layout to hide sidebar

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>QuizMaker</title>
   <link rel="icon" href="data:,">
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
@@ -45,6 +46,9 @@
       background: #2c3e50;
       color: #ecf0f1;
       padding: 20px;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
     }
     /* QuestionControls button accents */
     #addFillBtn { border-left: 4px solid #1abc9c; }
@@ -498,7 +502,7 @@
     </div>
   </div>
 
-  <div id="sidebar" style="display:flex; flex-direction:column; height:100vh;">
+  <div id="sidebar">
     <h3>Folders</h3>
     <ul id="folders" class="nav"></ul>
     <input id="newFolderName" placeholder="New folder name">


### PR DESCRIPTION
## Summary
- Ensure mobile devices use full-screen layout by adding a viewport meta tag.
- Move sidebar layout styles to CSS and drop inline styles so it can be hidden on mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f7d70e438832384e9c8d8d1f77ab7