### PR TITLE
Fix uninitialized variable error in quiz script

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1091,6 +1091,7 @@
       let deleteMode = false;     // controls red‑X visibility, must exist before render functions run
       let quizOrder = [], quizPos = 0;  // initialize quiz sequence and position early
       let lastSectionOrder = null;
+      let currentFolder = null, currentSection = null;
       // Track progress and random order per folder
       const quizProgress = {};  // { completed:Set, total, order:Array|null, pos:Number }
       let multiFolderMode = false;
@@ -1371,7 +1372,6 @@
         });
       }
 
-      let currentFolder = null, currentSection = null;
       let waitingForImagePaste = null; // {target:'main'|'extra', index?:number}
       let isAddingDefinition = false;
       const foldersUL = document.getElementById('folders'), sectionsUL = document.getElementById('sections'),


### PR DESCRIPTION
## Summary
- Initialize `currentFolder` and `currentSection` before they're referenced so progress indicators can run without throwing errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f88c8c5a88323bbf7349b190c418c