### PR TITLE
Fix mobile view initialization error

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1253,15 +1253,6 @@
         setRandomSelectMode(false);
       }
 
-      homeBtn.onclick = () => {
-        document.body.classList.remove('quiz-active');
-        isQuizMode = false;
-        quizArea.style.display = 'none';
-        currentFolder = null;
-        currentSection = null;
-        buildMobileFolderList();
-      };
-
       function questionCompleted() {
         const inputs = Array.from(document.querySelectorAll('#quizContent input[type="text"]'));
         if (!inputs.length) return true;
@@ -1395,6 +1386,15 @@
       const editorDiv = document.getElementById('editor');
       const folderBadge = document.getElementById('folderBadge');
       const headerTitle = document.getElementById('headerTitle');
+
+      homeBtn.onclick = () => {
+        document.body.classList.remove('quiz-active');
+        isQuizMode = false;
+        quizArea.style.display = 'none';
+        currentFolder = null;
+        currentSection = null;
+        buildMobileFolderList();
+      };
       // Whitelist pixel sizes for Quill's size format
       const Size = Quill.import('formats/size');
       Size.whitelist = ['8px','10px','12px','14px','16px','18px','20px','24px','28px','32px'];


### PR DESCRIPTION
## Summary
- defer Home button event handler until after DOM element initialization to avoid uninitialized variable error

## Testing
- `npm test` (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_688f8b7b7de483238bf0e6ab6ef1607a