### PR TITLE
Align mobile folder selection checkboxes

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -450,7 +450,13 @@
     #mobileStart input { width: 100%; padding: 8px; margin-bottom: 12px; }
     #mobileFolderList, #mobileSearchResults { list-style: none; padding: 0; margin: 0; }
     #mobileFolderList > li { padding: 0; }
-    #mobileFolderList > li > div.folder-header,
+    #mobileFolderList > li > div.folder-header {
+      display: flex;
+      align-items: center;
+      padding: 12px;
+      border-bottom: 1px solid #ccc;
+      cursor: pointer;
+    }
     #mobileSearchResults li {
       padding: 12px;
       border-bottom: 1px solid #ccc;
@@ -1141,8 +1147,10 @@
           cb.className = 'folder-select';
           cb.dataset.index = i;
           cb.style.display = 'none';
+          const titleSpan = document.createElement('span');
+          titleSpan.textContent = f.name;
           header.appendChild(cb);
-          header.appendChild(document.createTextNode(f.name));
+          header.appendChild(titleSpan);
           const secList = document.createElement('ul');
           secList.style.display = 'none';
           f.sections.forEach((s, si) => {


### PR DESCRIPTION
## Summary
- Keep folder checkboxes inline with titles on mobile by flexing folder headers and wrapping titles in spans.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688f9097bdc48323a9e816614394b884