### PR TITLE
Fix mobile folder header layout

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -456,6 +456,10 @@
       padding: 12px;
       border-bottom: 1px solid #ccc;
       cursor: pointer;
+      justify-content: flex-start;
+    }
+    #mobileFolderList > li > div.folder-header span {
+      flex: 0 0 auto;
     }
     #mobileSearchResults li {
       padding: 12px;


### PR DESCRIPTION
## Summary
- Keep mobile folder checkboxes and titles side by side on mobile

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f95ecba188323a4f89049c939aa2a