### PR TITLE
fix: align mobile folder titles

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -453,11 +453,13 @@
     #mobileFolderList > li > div.folder-header {
       display: flex;
       align-items: center;
+      gap: 8px;
       padding: 12px;
       border-bottom: 1px solid #ccc;
       cursor: pointer;
       justify-content: flex-start;
     }
+    #mobileFolderList > li > div.folder-header input.folder-select,
     #mobileFolderList > li > div.folder-header span {
       flex: 0 0 auto;
     }
@@ -473,7 +475,7 @@
       cursor: pointer;
       background: #f9f9f9;
     }
-    #mobileFolderList input.folder-select { margin-right: 8px; }
+    #mobileFolderList input.folder-select { margin-right: 0; }
     #mobileRandomBtn {
       margin-top: 12px;
       padding: 10px;


### PR DESCRIPTION
## Summary
- Ensure mobile folder titles stay beside their selection checkboxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9c8139548323896ab313f3254131