### PR TITLE
Fix mobile label input rendering

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -685,6 +685,9 @@
           if (el.dataset.origH) {
             el.style.height = (parseFloat(el.dataset.origH) * scaleY) + 'px';
           }
+          if (el.dataset.origLineHeight) {
+            el.style.lineHeight = (parseFloat(el.dataset.origLineHeight) * scaleY) + 'px';
+          }
         });
       }
 
@@ -1098,6 +1101,7 @@
             inp.style.background = '#ffffff';
             inp.style.fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
             inp.style.fontSize = lbl.fontSize + 'px';
+            inp.style.color = '#000';
             inp.style.padding = '0';
             inp.style.boxSizing = 'border-box';
             inp.style.minWidth = '0';
@@ -1114,8 +1118,10 @@
             const calcW = lbl.w ? lbl.w : (meas.offsetWidth + 4);
             document.body.removeChild(meas);
             const calcH = lbl.h || inp.offsetHeight;
-            inp.style.width = calcW + 'px';
+           inp.style.width = calcW + 'px';
             inp.style.height = calcH + 'px';
+            inp.style.lineHeight = calcH + 'px';
+            inp.dataset.origLineHeight = calcH;
             inp.dataset.origX = lbl.x;
             inp.dataset.origY = lbl.y;
             inp.dataset.origFont = lbl.fontSize;
@@ -1140,11 +1146,15 @@
                 const h = parseFloat(inp.dataset.origH);
                 txt.style.width = w + 'px';
                 txt.style.height = h + 'px';
+                txt.style.lineHeight = h + 'px';
                 txt.dataset.origX = lbl.x;
                 txt.dataset.origY = lbl.y;
                 txt.dataset.origFont = lbl.fontSize;
                 txt.dataset.origW = w;
                 txt.dataset.origH = h;
+                txt.dataset.origLineHeight = h;
+                txt.style.color = '#000';
+                txt.style.pointerEvents = 'none';
                 wrap.appendChild(txt);
                 inp.remove();
                 scaleLabels(wrap, baseW, baseH);
@@ -3628,6 +3638,7 @@
             inp.style.background = '#ffffff';
             inp.style.fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
             inp.style.fontSize = lbl.fontSize + 'px';
+            inp.style.color = '#000';
             inp.style.padding = '0';
             inp.style.boxSizing = 'border-box';
             inp.style.minWidth = '0';
@@ -3650,6 +3661,7 @@
             inp.style.height = calcH + 'px';
             // ensure typed text sits nicely within the box
             inp.style.lineHeight = calcH + 'px';
+            inp.dataset.origLineHeight = calcH;
             inp.dataset.origX = lbl.x;
             inp.dataset.origY = lbl.y;
             inp.dataset.origFont = lbl.fontSize;
@@ -3680,6 +3692,9 @@
                 txt.style.whiteSpace = 'nowrap';
                 txt.style.overflow   = 'hidden';
                 txt.style.lineHeight = h + 'px';
+                txt.dataset.origLineHeight = h;
+                txt.style.color = '#000';
+                txt.style.pointerEvents = 'none';
                 txt.dataset.origX = lbl.x;
                 txt.dataset.origY = lbl.y;
                 txt.dataset.origFont = lbl.fontSize;


### PR DESCRIPTION
## Summary
- keep label text visible by storing original line-height and color when answers are correct
- scale line-height for diagram labels to prevent cursor misalignment on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb3d366fc832396cd074d8a4aa230