### PR TITLE
Store quiz edits locally and add export button

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -602,6 +602,7 @@
       <div style="margin-top:12px;">
         <button id="previewBtn">Preview Words</button>
         <button id="saveSectionBtn">Save Section</button>
+        <button id="copyLocalBtn">Copy Local Changes</button>
         <button id="addPictureBtn" style="display:none;">Add Picture</button>
       </div>
       <div id="preview"></div>
@@ -1435,6 +1436,7 @@
       const GITHUB_JSON_URL = 'https://raw.githubusercontent.com/Ethan11San/Ethan11San.github.io/main/quizData.json';
       let data;
       let staticMode = false;
+      let unsyncedChanges = false;
       try {
         // Attempt API fetch
         const resp = await fetch('http://localhost:5001/api/quizData', { cache: 'no-store' });
@@ -1462,26 +1464,29 @@
           }
         }
       }
-      // Initialize currentFolder/Section based on loaded data...
-      function saveData() {
-        if (staticMode) {
-          console.warn('Static mode: changes will not be saved to server.');
-          return;
+
+      const stored = localStorage.getItem('quizDataLocal');
+      if (stored) {
+        try {
+          if (stored === JSON.stringify(data)) {
+            localStorage.removeItem('quizDataLocal');
+          } else {
+            data = JSON.parse(stored);
+            unsyncedChanges = true;
+          }
+        } catch (e) {
+          console.warn('Invalid local quiz data, ignoring', e);
+          localStorage.removeItem('quizDataLocal');
         }
-        fetch('http://localhost:5001/api/quizData', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data)
-        })
-        .then(resp => {
-          if (!resp.ok) throw new Error('Status ' + resp.status);
-        })
-        .catch(err => {
-          console.error('Error saving quiz data:', err);
-          alert('Error saving quiz data: ' + err.message);
-        });
       }
 
+      function saveData() {
+        localStorage.setItem('quizDataLocal', JSON.stringify(data));
+        unsyncedChanges = true;
+        if (copyLocalBtn) copyLocalBtn.disabled = false;
+      }
+
+      let copyLocalBtn;
       let waitingForImagePaste = null; // {target:'main'|'extra', index?:number}
       let isAddingDefinition = false;
       const foldersUL = document.getElementById('folders'), sectionsUL = document.getElementById('sections'),
@@ -1498,13 +1503,28 @@
             editorArea = document.getElementById('editorArea'),
             quizArea = document.getElementById('quizArea'),
             previewDiv = document.getElementById('preview'), previewBtn = document.getElementById('previewBtn'),
-            saveSectionBtn = document.getElementById('saveSectionBtn'), addPictureBtn = document.getElementById('addPictureBtn'), altContainer = document.getElementById('altContainer'),
+            saveSectionBtn = document.getElementById('saveSectionBtn'), copyLocalBtn = document.getElementById('copyLocalBtn'), addPictureBtn = document.getElementById('addPictureBtn'), altContainer = document.getElementById('altContainer'),
             quizContent = document.getElementById('quizContent'), backBtn = document.getElementById('backBtn'), nextBtn = document.getElementById('nextBtn'), homeBtn = document.getElementById('homeBtn'), mobileRandomBtn = document.getElementById('mobileRandomBtn'), mobileRandomGo = document.getElementById('mobileRandomGo');
       const toggleDeleteBtn = document.getElementById('toggleDeleteBtn');
       const clearSearchBtn = document.getElementById('clearSearchBtn');
       const editorDiv = document.getElementById('editor');
       const folderBadge = document.getElementById('folderBadge');
       const headerTitle = document.getElementById('headerTitle');
+
+      copyLocalBtn.disabled = !unsyncedChanges;
+      copyLocalBtn.onclick = () => {
+        const storedData = localStorage.getItem('quizDataLocal');
+        if (!storedData) {
+          alert('No local changes to copy.');
+          return;
+        }
+        navigator.clipboard.writeText(storedData)
+          .then(() => alert('Local changes copied to clipboard.'))
+          .catch(err => {
+            console.error('Clipboard error:', err);
+            alert('Failed to copy: ' + err.message);
+          });
+      };
 
       homeBtn.onclick = () => {
         document.body.classList.remove('quiz-active');

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@ This repository contains the `QuizMaker` web app and its data file `quizData.jso
 
 When loaded, `QuizMaker.html` will attempt to fetch quiz data from a local API
 (`http://localhost:5001/api/quizData`). If that fails, it falls back to the
-bundled `quizData.json`. If the JSON file cannot be loaded locally (for example
-when opening the page directly from the file system), a final fallback fetches
-`quizData.json` from the GitHub repository.
+bundled `quizData.json` or the copy hosted on GitHub.
+
+Any edits you make are stored in your browser's local storage. Use the
+**Copy Local Changes** button to copy the entire JSON to your clipboard and
+send it for inclusion in `quizData.json`. When the repository version matches
+your local copy, the saved changes are cleared from the browser automatically.
 
 ## Changing folder colors
 


### PR DESCRIPTION
## Summary
- Persist quiz edits in browser local storage instead of POSTing to a local API
- Add "Copy Local Changes" button that copies unsynced JSON to clipboard for manual updates
- Document new local storage workflow in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fe6f3d6a0832383b12811e833c334