### PR TITLE
fix: ignore invalid local quiz data

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1468,10 +1468,11 @@
       const stored = localStorage.getItem('quizDataLocal');
       if (stored) {
         try {
-          if (stored === JSON.stringify(data)) {
+          const parsed = JSON.parse(stored);
+          if (JSON.stringify(parsed) === JSON.stringify(data) || !Array.isArray(parsed.folders)) {
             localStorage.removeItem('quizDataLocal');
           } else {
-            data = JSON.parse(stored);
+            data = parsed;
             unsyncedChanges = true;
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- prevent empty or corrupted local quiz data from overriding GitHub data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ff7aff1208323bf6ea868776f86ab