### PR TITLE
Fix local data override and mobile detection

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1239,7 +1239,7 @@
       }
 
       function isMobileDevice() {
-        return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent);
+        return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) || window.innerWidth <= 768;
       }
 
       function setupMobileUI() {
@@ -1479,11 +1479,13 @@
       if (stored) {
         try {
           const parsed = JSON.parse(stored);
-          if (JSON.stringify(parsed) === JSON.stringify(data) || !Array.isArray(parsed.folders)) {
+          if (!Array.isArray(parsed.folders) || parsed.folders.length === 0) {
             localStorage.removeItem('quizDataLocal');
-          } else {
+          } else if (JSON.stringify(parsed) !== JSON.stringify(data)) {
             data = parsed;
             unsyncedChanges = true;
+          } else {
+            localStorage.removeItem('quizDataLocal');
           }
         } catch (e) {
           console.warn('Invalid local quiz data, ignoring', e);


### PR DESCRIPTION
## Summary
- Ignore empty or identical local quiz data so GitHub questions load correctly
- Broaden mobile detection to use user agent or screen width

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689001343a54832398c19fac37f4af9e