### PR TITLE
fix: prioritize GitHub quiz data over stale local copy

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1481,7 +1481,7 @@
           const parsed = JSON.parse(stored);
           if (!Array.isArray(parsed.folders) || parsed.folders.length === 0) {
             localStorage.removeItem('quizDataLocal');
-          } else if (JSON.stringify(parsed) !== JSON.stringify(data)) {
+          } else if (!data || !Array.isArray(data.folders) || data.folders.length === 0) {
             data = parsed;
             unsyncedChanges = true;
           } else {


### PR DESCRIPTION
## Summary
- ensure local storage only used when no remote data loads

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68900f529e408323b12bd03b32e26f00