### PR TITLE
fix: sync edits when starting quizzes

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1279,6 +1279,10 @@
             sli.textContent = title;
             sli.onclick = e => {
               e.stopPropagation();
+              if (!isQuizMode) {
+                syncCurrentSection();
+                if (typeof quill !== 'undefined') quill.blur();
+              }
               currentFolder = i;
               currentSection = si;
               multiFolderMode = false;
@@ -1344,6 +1348,10 @@
               const li = document.createElement('li');
               li.textContent = `${f.name}: ${title}`;
               li.onclick = () => {
+                if (!isQuizMode) {
+                  syncCurrentSection();
+                  if (typeof quill !== 'undefined') quill.blur();
+                }
                 currentFolder = fi;
                 currentSection = si;
                 multiFolderMode = false;
@@ -1358,6 +1366,10 @@
 
       function enterRandomQuizAcrossFolders(folders) {
         if (!folders.length) return;
+        if (!isQuizMode) {
+          syncCurrentSection();
+          if (typeof quill !== 'undefined') quill.blur();
+        }
         multiFolderMode = true;
         isQuizMode = true;
         const combined = [];


### PR DESCRIPTION
## Summary
- ensure mobile folder list saves edits before launching quizzes
- save edits when starting quiz from mobile search results
- sync edits when starting multi-folder random quizzes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891011642f883238879a416e614d5dd