### PR TITLE
Handle localStorage errors when saving quiz data

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1579,12 +1579,18 @@
 
       function saveData() {
         const diff = computeDiff(originalData, data);
-        if (diff && Object.keys(diff).length) {
-          localStorage.setItem('quizDataLocal', JSON.stringify(diff));
-          unsyncedChanges = true;
-          if (copyLocalBtn) copyLocalBtn.disabled = false;
-        } else {
-          localStorage.removeItem('quizDataLocal');
+        try {
+          if (diff && Object.keys(diff).length) {
+            localStorage.setItem('quizDataLocal', JSON.stringify(diff));
+            unsyncedChanges = true;
+            if (copyLocalBtn) copyLocalBtn.disabled = false;
+          } else {
+            localStorage.removeItem('quizDataLocal');
+            unsyncedChanges = false;
+            if (copyLocalBtn) copyLocalBtn.disabled = true;
+          }
+        } catch (e) {
+          console.warn('Failed to persist local quiz data', e);
           unsyncedChanges = false;
           if (copyLocalBtn) copyLocalBtn.disabled = true;
         }


### PR DESCRIPTION
## Summary
- prevent localStorage quota errors from freezing the app when saving quiz data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910442a3808323aa64677025a704b2