### PR TITLE
Adjust mobile font size for fill‑in questions

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -371,6 +371,16 @@
     .blank input:focus { outline: none; border-bottom-color: #3498db; }
     .blank input.correct { border-bottom-color: #27ae60; }
     .blank input.incorrect { border-bottom-color: #c0392b; }
+    @media (max-width: 600px) {
+      #quizArea,
+      #quizContent {
+        font-size: 1rem;
+      }
+      #quizContent .blank input,
+      .blank input {
+        font-size: 1rem;
+      }
+    }
     #nextBtn, #backBtn {
       margin-top: 20px; padding: 10px 20px;
       border: none; border-radius: 4px;


### PR DESCRIPTION
## Summary
- reduce font size for quiz area and blank inputs on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891126337648323ae9015f68d3d8a79