### PR TITLE
Speed up mobile layout rendering

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -39,6 +39,30 @@
       font-family: -apple-system, BlinkMacSystemFont, sans-serif;
       background: #ecf0f1; color: #333;
     }
+    body.loading {
+      display: block;
+    }
+    body.loading #sidebar,
+    body.loading #main,
+    body.loading #mobileStart {
+      display: none;
+    }
+    #loadingScreen {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: #ecf0f1;
+      color: #333;
+      font-size: 1.2rem;
+    }
+    body.loading #loadingScreen {
+      display: flex;
+    }
 
     /* —— Sidebar —— */
     #sidebar {
@@ -535,7 +559,17 @@
     }
   </style>
 </head>
-<body>
+<body class="loading">
+
+  <script>
+    const earlyMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) || window.innerWidth <= 768;
+    if (earlyMobile) {
+      document.body.classList.add('mobile');
+    } else {
+      document.body.classList.remove('loading');
+    }
+  </script>
+  <div id="loadingScreen">Loading...</div>
 
   <div id="mobileStart">
     <input type="text" id="mobileSearch" placeholder="Search questions...">
@@ -1816,9 +1850,9 @@
         updateHeader('QuizMaker');
       }
       if (isMobileDevice()) {
-        document.body.classList.add('mobile');
         setupMobileUI();
       }
+      document.body.classList.remove('loading');
 
       // --- Auto-resize editor textarea with content up to its max height ---
       // function adjustEditorHeight() {


### PR DESCRIPTION
## Summary
- Detect mobile devices immediately and apply mobile layout before page render
- Add loading screen and CSS to hide desktop layout while mobile UI initializes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912560a398832387024fb648be0b9b