### PR TITLE
Improve mobile folder loading speed

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -7,6 +7,8 @@
   <link rel="icon" href="data:,">
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
   <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+  <link rel="preload" href="quizData.json" as="fetch" crossorigin="anonymous">
+  <link rel="preload" href="imageData.json" as="fetch" crossorigin="anonymous">
   <style>
     /* Ensure formatted spans do not disrupt line spacing */
     #editor span {
@@ -587,7 +589,7 @@
 
   <div id="mobileStart">
     <input type="text" id="mobileSearch" placeholder="Search questions...">
-    <ul id="mobileFolderList"></ul>
+    <ul id="mobileFolderList"><li class="loading">Loading folders...</li></ul>
     <ul id="mobileSearchResults" style="display:none;"></ul>
     <button id="mobileRandomBtn">Random Quiz</button>
     <button id="copyLocalBtn">Copy Local Changes</button>


### PR DESCRIPTION
## Summary
- Preload `quizData.json` and `imageData.json` to kick off data fetch earlier
- Show a temporary placeholder while mobile folders load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914773f76c8323908c4147af16392f