### PR TITLE
Fix mobile folder list ordering

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1321,15 +1321,8 @@
       function buildMobileFolderList() {
         const list = document.getElementById('mobileFolderList');
         list.innerHTML = '';
-        const unique = [];
-        const seen = new Set();
-        for (let i = data.folders.length - 1; i >= 0; i--) {
-          const f = data.folders[i];
-          if (!f || !f.name || seen.has(f.name)) continue;
-          seen.add(f.name);
-          unique.unshift({ f, i });
-        }
-        unique.forEach(({ f, i }) => {
+        data.folders.forEach((f, i) => {
+          if (!f || !f.name) return;
           const li = document.createElement('li');
           const header = document.createElement('div');
           header.className = 'folder-header';


### PR DESCRIPTION
## Summary
- Ensure mobile folder list iterates over all folders in order, preventing missing or reordered entries on mobile devices.

## Testing
- `npm test` *(fails: no such file or directory, package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916c407eec8323a714b056551216f5