### PR TITLE
Fix excessive local changes diff

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1598,14 +1598,24 @@
 
       function stripImageData(obj) {
         if (typeof obj !== 'object' || obj === null) return obj;
-        delete obj.image;
+        if (Array.isArray(obj)) {
+          const arr = [];
+          obj.forEach((item, idx) => {
+            const val = stripImageData(item);
+            if (!(typeof val === 'object' && val !== null && Object.keys(val).length === 0)) {
+              arr[idx] = val;
+            }
+          });
+          return arr;
+        }
+        const out = {};
         Object.keys(obj).forEach(key => {
+          if (key === 'image') return;
           const val = stripImageData(obj[key]);
-          if (typeof val === 'object' && val !== null && Object.keys(val).length === 0) {
-            delete obj[key];
-          }
+          if (typeof val === 'object' && val !== null && Object.keys(val).length === 0) return;
+          out[key] = val;
         });
-        return obj;
+        return out;
       }
 
       if (isLocalEnv) {


### PR DESCRIPTION
## Summary
- Avoid mutating data when stripping image fields so local diff only tracks real edits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917bb75bac8323bbb3cdfe0a8ca636