### PR TITLE
Preserve label position and size changes locally

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1775,9 +1775,10 @@
           return arr;
         }
         const out = {};
+        // Only exclude raw image data fields so position/size info persists in localStorage
         const imgKeys = new Set([
-          'image','img','imgWidth','imgHeight','imgX','imgY',
-          'x','y','w','h','fontSize','arrows'
+          'image', // main/base64 image data
+          'img'    // generic image field used in some structures
         ]);
         Object.keys(obj).forEach(key => {
           if (imgKeys.has(key)) return;


### PR DESCRIPTION
## Summary
- Keep label coordinates, font size, and image dimensions in localStorage diffs while still excluding raw image data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689289e0123883239bdef4ce8af91c67