### PR TITLE
fix: prevent copy failures after remote sync check

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1963,15 +1963,17 @@
       }
 
       updateLocalButtons();
-      copyLocalBtns.forEach(btn => btn.onclick = async () => {
-        await verifyAndClearLocal();
+      copyLocalBtns.forEach(btn => btn.onclick = () => {
         const storedData = localStorage.getItem('quizDataLocal');
         if (!storedData) {
           alert('No local changes to copy.');
           return;
         }
         navigator.clipboard.writeText(storedData)
-          .then(() => alert('Local changes copied to clipboard.'))
+          .then(() => {
+            alert('Local changes copied to clipboard.');
+            verifyAndClearLocal();
+          })
           .catch(err => {
             console.error('Clipboard error:', err);
             alert('Failed to copy: ' + err.message);


### PR DESCRIPTION
## Summary
- call clipboard API immediately on button click to preserve user activation
- verify remote data after copy succeeds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689572e79ba08323b669960172699a74