### PR TITLE
Fix resume button redeclaration breaking mobile load

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1951,7 +1951,8 @@
             editorArea = document.getElementById('editorArea'),
             quizArea = document.getElementById('quizArea'),
             previewDiv = document.getElementById('preview'), addPictureBtn = document.getElementById('addPictureBtn'), altContainer = document.getElementById('altContainer'),
-            quizContent = document.getElementById('quizContent'), backBtn = document.getElementById('backBtn'), nextBtn = document.getElementById('nextBtn'), hintBtn = document.getElementById('hintBtn'), editQuestionBtn = document.getElementById('editQuestionBtn'), homeBtn = document.getElementById('homeBtn'), mobileRandomBtn = document.getElementById('mobileRandomBtn'), mobileRandomGo = document.getElementById('mobileRandomGo'), resumeRandomBtn = document.getElementById('resumeRandomBtn');
+            quizContent = document.getElementById('quizContent'), backBtn = document.getElementById('backBtn'), nextBtn = document.getElementById('nextBtn'), hintBtn = document.getElementById('hintBtn'), editQuestionBtn = document.getElementById('editQuestionBtn'), homeBtn = document.getElementById('homeBtn'), mobileRandomBtn = document.getElementById('mobileRandomBtn'), mobileRandomGo = document.getElementById('mobileRandomGo');
+      resumeRandomBtn = document.getElementById('resumeRandomBtn');
       copyLocalBtns = Array.from(document.querySelectorAll('.copy-local-btn'));
       clearLocalBtns = Array.from(document.querySelectorAll('.clear-local-btn'));
       resumeQuizBtn = document.getElementById('resumeQuizBtn');


### PR DESCRIPTION
## Summary
- Avoid redeclaring `resumeRandomBtn` to prevent syntax errors

## Testing
- `node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
 const browser = await puppeteer.launch({headless: 'new', args:['--no-sandbox','--disable-setuid-sandbox']});
 const page = await browser.newPage();
 page.on('console', msg => console.log('PAGE LOG:', msg.type(), msg.text()));
 page.on('pageerror', err => console.log('PAGE ERROR:', err.toString()));
 await page.goto('file://' + process.cwd() + '/QuizMaker.html');
 await new Promise(r => setTimeout(r, 2000));
 await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68958b39ec7483239065cf7738954cf0