### PR TITLE
Align mobile local storage buttons

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -573,14 +573,17 @@
       font-weight: 500;
     }
 
-    /* Compact side-by-side local storage buttons for desktop */
-    #desktopLocalBtns {
+    /* Compact side-by-side local storage buttons for desktop and mobile */
+    #desktopLocalBtns,
+    #mobileLocalBtns {
       margin-top: 8px;
       display: flex;
       gap: 8px;
     }
     #desktopLocalBtns .copy-local-btn,
-    #desktopLocalBtns .clear-local-btn {
+    #desktopLocalBtns .clear-local-btn,
+    #mobileLocalBtns .copy-local-btn,
+    #mobileLocalBtns .clear-local-btn {
       flex: 1;
       padding: 6px;
       margin-top: 0;
@@ -630,8 +633,10 @@
     <ul id="mobileFolderList"><li class="loading">Loading folders...</li></ul>
     <ul id="mobileSearchResults" style="display:none;"></ul>
     <button id="mobileRandomBtn">Random Quiz</button>
-    <button id="copyLocalBtn" class="copy-local-btn">Copy Local Changes</button>
-    <button id="clearLocalBtn" class="clear-local-btn">Clear Local Storage</button>
+    <div id="mobileLocalBtns">
+      <button id="copyLocalBtn" class="copy-local-btn">Copy Local Changes</button>
+      <button id="clearLocalBtn" class="clear-local-btn">Clear Local Storage</button>
+    </div>
     <button id="resumeRandomBtn" style="display:none;">Resume</button>
     <button id="mobileRandomGo">Go</button>
   </div>


### PR DESCRIPTION
## Summary
- Show "Copy Local Changes" and "Clear Local Storage" side-by-side on the mobile home screen.
- Shrink both buttons via shared flex styles to save vertical space.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689648411a108323bedf23e162f62219