### PR TITLE
Align mobile local storage buttons with surrounding controls

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -581,11 +581,16 @@
       gap: 8px;
     }
     #desktopLocalBtns .copy-local-btn,
-    #desktopLocalBtns .clear-local-btn,
+    #desktopLocalBtns .clear-local-btn {
+      flex: 1;
+      padding: 6px;
+      margin-top: 0;
+      width: auto;
+    }
     #mobileLocalBtns .copy-local-btn,
     #mobileLocalBtns .clear-local-btn {
       flex: 1;
-      padding: 6px;
+      padding: 10px;
       margin-top: 0;
       width: auto;
     }


### PR DESCRIPTION
## Summary
- Adjust mobile local storage clear/copy buttons to match the height of surrounding controls.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689649cbd438832399b91b5577e0f656