### PR TITLE
Reset baseline after syncing local changes

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2040,6 +2040,10 @@
           if (!diff || !Object.keys(diff).length) {
             localStorage.removeItem('quizDataLocal');
             unsyncedChanges = false;
+            // Reset baseline data so future saves don't keep re-copying
+            // already-synced changes.
+            data = remote;
+            originalData = JSON.parse(JSON.stringify(remote));
             updateLocalButtons();
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- Reset `data` and `originalData` after verifying remote JSON to prevent already synced changes from being copied again.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc46eb608323b2fae814af6dc6d3