### PR TITLE
Fix hide toolbar button selection handling

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2388,7 +2388,7 @@
       const addImageWordBtn = document.getElementById('addImageWordBtn');
       addImageWordBtn.addEventListener('click', async () => {
         if (!ensureSelection()) return;
-        const range = quill.getSelection();
+        const range = quill.getSelection(true);
         if (!range || range.length === 0) return alert('Select text first');
         async function getClipboardImage() {
           try {
@@ -2425,7 +2425,7 @@
       const hideBtn = document.getElementById('hideBtn');
       hideBtn.addEventListener('click', () => {
         if (!ensureSelection()) return;
-        const range = quill.getSelection();
+        const range = quill.getSelection(true);
         if (!range || range.length === 0) return alert('Select text first');
         quill.formatText(range.index, range.length, 'hiddenReveal', true, 'user');
         const [leaf] = quill.getLeaf(range.index);


### PR DESCRIPTION
## Summary
- ensure custom toolbar buttons keep the last editor selection using `quill.getSelection(true)` so the hide button works again

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0c63db208323b09e62c537dd42e4