### PR TITLE
Fix hide button applying hidden reveal

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2177,6 +2177,7 @@
       const clearSearchBtn = document.getElementById('clearSearchBtn');
       const editorDiv = document.getElementById('editor');
       let pendingRevealSpan = null;
+      let lastRange = null;
       const folderBadge = document.getElementById('folderBadge');
       const headerTitle = document.getElementById('headerTitle');
       const headerElem = document.getElementById('header');
@@ -2364,6 +2365,9 @@
         },
         theme: 'snow'
       });
+      quill.on('selection-change', range => {
+        if (range) lastRange = range;
+      });
       // Auto‑expand the editor height to fit its content
       function adjustEditorHeight() {
         const root      = quill.root;             // editable area (ql-editor)
@@ -2425,11 +2429,12 @@
       const hideBtn = document.getElementById('hideBtn');
       hideBtn.addEventListener('click', () => {
         if (!ensureSelection()) return;
-        const range = quill.getSelection(true);
+        const range = lastRange;
         if (!range || range.length === 0) return alert('Select text first');
         quill.formatText(range.index, range.length, 'hiddenReveal', true, 'user');
         const [leaf] = quill.getLeaf(range.index);
-        const span = leaf.domNode.closest('.hidden-reveal');
+        const span = leaf && leaf.domNode ? leaf.domNode.closest('.hidden-reveal') : null;
+        if (!span) return;
         if (pendingRevealSpan) pendingRevealSpan.classList.remove('pending');
         pendingRevealSpan = span;
         span.classList.add('pending');


### PR DESCRIPTION
## Summary
- preserve last selected range to hide text reliably
- guard against missing span when linking hidden reveal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0f152e2483239b4d0f66d9790d35