### PR TITLE
Handle text nodes when applying hidden reveal

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2433,7 +2433,9 @@
         if (!range || range.length === 0) return alert('Select text first');
         quill.formatText(range.index, range.length, 'hiddenReveal', true, 'user');
         const [leaf] = quill.getLeaf(range.index);
-        const span = leaf && leaf.domNode ? leaf.domNode.closest('.hidden-reveal') : null;
+        const span =
+          leaf?.domNode?.closest?.('.hidden-reveal') ||
+          leaf?.domNode?.parentElement?.closest('.hidden-reveal');
         if (!span) return;
         if (pendingRevealSpan) pendingRevealSpan.classList.remove('pending');
         pendingRevealSpan = span;


### PR DESCRIPTION
## Summary
- Avoid TypeError when Hide button is clicked by checking for text nodes and falling back to parent elements before calling `closest`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a121abf7c83239106bcfc7beb6ba4