### PR TITLE
Fix hide button selection handling

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2366,7 +2366,7 @@
         theme: 'snow'
       });
       quill.on('selection-change', range => {
-        if (range) lastRange = range;
+        if (range && range.length > 0) lastRange = range;
       });
       // Auto‑expand the editor height to fit its content
       function adjustEditorHeight() {


### PR DESCRIPTION
## Summary
- Preserve user text selection when clicking hide button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a13a705348323a8ff95dcf4275a8f