### PR TITLE
fix hide button selection retrieval

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -2429,7 +2429,9 @@
       const hideBtn = document.getElementById('hideBtn');
       hideBtn.addEventListener('click', () => {
         if (!ensureSelection()) return;
-        const range = lastRange;
+        // When the toolbar button is clicked Quill loses focus, so rely on
+        // Quill's "silent" selection retrieval to get the last active range.
+        const range = quill.getSelection(true) || lastRange;
         if (!range || range.length === 0) return alert('Select text first');
         quill.formatText(range.index, range.length, 'hiddenReveal', true, 'user');
         const [leaf] = quill.getLeaf(range.index);


### PR DESCRIPTION
## Summary
- ensure hide button retrieves last text selection even after toolbar focus loss

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a16d3c5f483239ff2518a6289aa90