### PR TITLE
Limit highlighting of blanks to linking mode

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -280,11 +280,11 @@
     .word.hidden {
       color: transparent;
       text-shadow: 0 0 5px #000;
-      background: #fff3cd;
       border-bottom: 1px dashed #f39c12;
     }
-    .word.hidden.linked { background: #d4edda; }
-    .hidden-reveal {
+    body.linking .word.hidden { background: #fff3cd; }
+    body.linking .word.hidden.linked { background: #d4edda; }
+    body.linking #editor .hidden-reveal {
       background: #fff3cd;
       border-bottom: 1px dashed #f39c12;
     }


### PR DESCRIPTION
## Summary
- Only show blank and reveal highlights while linking
- Keep pending hidden text highlighted during linking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a2f2784c88323b16ef29bb0b038af