### PR TITLE
Highlight hidden text when using hide button

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -284,7 +284,7 @@
     }
     body.linking .word.hidden { background: #fff3cd; }
     body.linking .word.hidden.linked { background: #d4edda; }
-    body.linking #editor .hidden-reveal {
+    #editor .hidden-reveal {
       background: #fff3cd;
       border-bottom: 1px dashed #f39c12;
     }


### PR DESCRIPTION
## Summary
- Always style `.hidden-reveal` spans in the editor so hidden text is visibly highlighted.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a38a425a08323ab82fd9ec408cadf