### PR TITLE
Add token-to-blank linking workflow

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -654,6 +654,15 @@
       height: auto;
     }
   </style>
+  <style id="linkingStyles">
+#linkBtn{display:none}
+#linkBtn.show{display:inline-block}
+.source-token{background:rgba(255,238,150,.6);border-radius:4px;padding:0 2px}
+.source-token.linking{outline:2px solid orange;background:rgba(255,210,120,.85)}
+.blank{outline:1px dashed #999;padding:0 2px;border-radius:4px}
+.blank.linked{outline:2px solid #4a7}
+#preview.linking-ready .blank{cursor:crosshair;outline-color:#37f}
+  </style>
 </head>
 <body class="loading">
 
@@ -758,6 +767,7 @@
         <button id="addImageWordBtn">🖼️</button>
       </div>
       <div id="editor" style="height: 200px; background: #fff;"></div>
+      <button id="linkBtn" type="button" aria-hidden="true" title="Link to a blank">Link selection → blank</button>
       <div style="margin-top:12px;">
         <button id="resumeQuizBtn" style="display:none;">Back to Quiz</button>
         <button id="addPictureBtn" style="display:none;">Add Picture</button>
@@ -5389,6 +5399,186 @@
       alert('Unhandled error: ' + err.message);
     }
   })();
+  </script>
+  <script>
+(() => {
+  const source = document.querySelector('#editor');
+  const blanks = document.querySelector('#preview');
+  const linkBtn = document.querySelector('#linkBtn');
+  if (!source || !blanks || !linkBtn) return console.warn('Missing editors or button');
+
+  // Ensure blanks have .blank + ids (convert runs of 3+ underscores)
+  initBlanks();
+
+  let currentToken = null; // element in linking mode
+
+  document.addEventListener('selectionchange', () => {
+    const r = getRangeIn(source);
+    toggleLinkBtn(!!r && !r.collapsed);
+  });
+
+  linkBtn.addEventListener('click', () => {
+    const r = getRangeIn(source);
+    if (!r || r.collapsed) return;
+    const token = wrapSelectionAsToken(r);
+    enterLinkingMode(token);
+  });
+
+  blanks.addEventListener('click', (e) => {
+    const target = e.target.closest('.blank');
+    if (!target) return;
+    if (!currentToken) return; // only link while linking
+    linkTokenToBlank(currentToken, target);
+    exitLinkingMode();
+  });
+
+  source.addEventListener('click', (e) => {
+    const t = e.target.closest('.source-token');
+    if (!t) return;
+    // clicking a token always lets you (re)assign
+    enterLinkingMode(t);
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && currentToken) {
+      exitLinkingMode();
+    }
+  });
+
+  // ---- helpers ----
+  function toggleLinkBtn(on) {
+    linkBtn.classList.toggle('show', on);
+    linkBtn.ariaHidden = (!on).toString();
+    linkBtn.disabled = !on;
+  }
+
+  function getRangeIn(container) {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return null;
+    const r = sel.getRangeAt(0);
+    const inContainer =
+      container.contains(r.startContainer) && container.contains(r.endContainer);
+    return inContainer ? r : null;
+  }
+
+  function wrapSelectionAsToken(range) {
+    // If selection already entirely inside an existing token, reuse it
+    const commonEl = range.commonAncestorContainer.nodeType === 1
+      ? range.commonAncestorContainer
+      : range.commonAncestorContainer.parentElement;
+    const existing = commonEl && commonEl.closest('.source-token');
+    if (existing && existing.contains(range.cloneContents())) {
+      return existing;
+    }
+
+    // Create token
+    const span = document.createElement('span');
+    span.className = 'source-token';
+    span.dataset.tokenId = span.dataset.tokenId || 't' + cryptoRandom();
+    span.tabIndex = 0;
+
+    // Extract + insert
+    const frag = range.extractContents();
+    // Trim leading/trailing whitespace to keep highlight tight
+    trimFragmentWhitespace(frag);
+    span.appendChild(frag);
+    range.insertNode(span);
+
+    // Merge if we accidentally split text nodes around it
+    span.normalize();
+    return span;
+  }
+
+  function enterLinkingMode(token) {
+    if (currentToken) exitLinkingMode();
+    currentToken = token;
+    token.classList.add('linking');
+    blanks.classList.add('linking-ready');
+  }
+
+  function exitLinkingMode() {
+    if (!currentToken) return;
+    currentToken.classList.remove('linking');
+    blanks.classList.remove('linking-ready');
+    currentToken = null;
+  }
+
+  function linkTokenToBlank(token, blank) {
+    // Unlink previous pairings if any
+    if (token.dataset.blankId) {
+      const old = blanks.querySelector(`.blank[data-blank-id="${token.dataset.blankId}"]`);
+      if (old) unlinkBoth(token, old);
+    }
+    if (blank.dataset.tokenId) {
+      const old = source.querySelector(`.source-token[data-token-id="${blank.dataset.tokenId}"]`);
+      if (old) unlinkBoth(old, blank);
+    }
+
+    // Ensure both have ids
+    token.dataset.tokenId = token.dataset.tokenId || 't' + cryptoRandom();
+    blank.dataset.blankId = blank.dataset.blankId || 'b' + cryptoRandom();
+
+    // Link
+    token.dataset.blankId = blank.dataset.blankId;
+    blank.dataset.tokenId = token.dataset.tokenId;
+
+    token.classList.add('linked');
+    blank.classList.add('linked');
+  }
+
+  function unlinkBoth(token, blank) {
+    delete token.dataset.blankId;
+    delete blank.dataset.tokenId;
+    token.classList.remove('linked');
+    blank.classList.remove('linked');
+  }
+
+  function initBlanks() {
+    // Give existing .blank spans ids; convert "____" runs into .blank
+    blanks.querySelectorAll('.blank').forEach((b, i) => {
+      if (!b.dataset.blankId) b.dataset.blankId = 'b' + (i+1);
+    });
+    // Convert raw underscores to spans
+    const walker = document.createTreeWalker(blanks, NodeFilter.SHOW_TEXT, null);
+    const toReplace = [];
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      if (node.nodeValue && /_{3,}/.test(node.nodeValue)) toReplace.push(node);
+    }
+    toReplace.forEach(node => {
+      const parts = node.nodeValue.split(/(_{3,})/);
+      const frag = document.createDocumentFragment();
+      let blankCount = blanks.querySelectorAll('.blank').length;
+      parts.forEach(p => {
+        if (!p) return;
+        if (/_{3,}/.test(p)) {
+          const s = document.createElement('span');
+          s.className = 'blank';
+          s.dataset.blankId = 'b' + (++blankCount);
+          s.textContent = '____';
+          frag.appendChild(s);
+        } else {
+          frag.appendChild(document.createTextNode(p));
+        }
+      });
+      node.parentNode.replaceChild(frag, node);
+    });
+  }
+
+  function trimFragmentWhitespace(frag) {
+    // remove leading/trailing whitespace text nodes inside fragment
+    let first = frag.firstChild, last = frag.lastChild;
+    if (first && first.nodeType === 3) first.nodeValue = first.nodeValue.replace(/^\s+/, '');
+    if (last && last.nodeType === 3) last.nodeValue = last.nodeValue.replace(/\s+$/, '');
+  }
+
+  function cryptoRandom() {
+    // short id
+    const a = new Uint32Array(2);
+    (window.crypto || window.msCrypto).getRandomValues(a);
+    return (a[0]>>>0).toString(36) + (a[1]>>>0).toString(36);
+  }
+})();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add hidden link button and styles for linking source selections to blanks
- Insert button after editor and implement script to wrap selections and link to blanks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5a9911e883239a82ad8b5f06b893