### PR TITLE
Fix link selection losing selection

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -5411,17 +5411,21 @@
     initBlanks();
 
     let currentToken = null;
+    let storedRange = null;
 
     const toggleBtn = () => {
       const r = getRangeIn(source);
       console.log('toggleBtn range', r);
       linkBtn.hidden = !(r && !r.collapsed);
+      storedRange = r && !r.collapsed ? r.cloneRange() : null;
     };
 
     document.addEventListener('selectionchange', toggleBtn);
 
+    linkBtn.addEventListener('mousedown', e => e.preventDefault());
+
     linkBtn.addEventListener('click', () => {
-      const r = getRangeIn(source);
+      const r = storedRange;
       console.log('linkBtn click range', r);
       if (!r || r.collapsed) return;
       const token = wrapSelectionAsToken(r);


### PR DESCRIPTION
## Summary
- preserve the current text selection when linking words to blanks
- prevent the link button from stealing focus from the editor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7ac15e5483238f995fcfa7df9f35