### PR TITLE
Fix linking mode to capture selection and blanks correctly

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -5425,7 +5425,7 @@
     linkBtn.addEventListener('mousedown', e => e.preventDefault());
 
     linkBtn.addEventListener('click', () => {
-      const r = storedRange;
+      const r = storedRange || getRangeIn(source);
       console.log('linkBtn click range', r);
       if (!r || r.collapsed) return;
       const token = wrapSelectionAsToken(r);
@@ -5438,10 +5438,12 @@
       linkBtn.hidden = true;
     });
 
-    blanks.addEventListener('click', e => {
+    blanks.addEventListener('mousedown', e => {
       const target = e.target.closest('.blank');
       console.log('blank clicked', { target, currentToken });
       if (!target || !currentToken) return;
+      e.preventDefault();
+      e.stopPropagation();
       linkTokenToBlank(currentToken, target);
       exitLinkingMode();
     });


### PR DESCRIPTION
## Summary
- Keep a fallback range when creating tokens so the selection doesn't disappear before wrapping
- Handle blank clicks on mousedown with `preventDefault`/`stopPropagation` to reliably link tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7e3583988323aedb0b0f182c56a5