### PR TITLE
Fix linking mode to capture selection and blanks correctly

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -5425,7 +5425,7 @@
     linkBtn.addEventListener('mousedown', e => e.preventDefault());
 
     linkBtn.addEventListener('click', () => {
-      const r = storedRange;
+      const r = storedRange || getRangeIn(source);
       console.log('linkBtn click range', r);
       if (!r || r.collapsed) return;
       const token = wrapSelectionAsToken(r);
@@ -5438,18 +5438,23 @@
       linkBtn.hidden = true;
     });
 
-    blanks.addEventListener('click', e => {
-      const target = e.target.closest('.blank');
+    blanks.addEventListener('mousedown', e => {
+      const target = e.composedPath().find(el =>
+        el instanceof HTMLElement && el.classList.contains('blank'));
       console.log('blank clicked', { target, currentToken });
       if (!target || !currentToken) return;
+      e.preventDefault();
+      e.stopPropagation();
       linkTokenToBlank(currentToken, target);
       exitLinkingMode();
     });
 
-    source.addEventListener('click', e => {
-      const t = e.target.closest('.source-token');
+    source.addEventListener('mousedown', e => {
+      const t = e.composedPath().find(el =>
+        el instanceof HTMLElement && el.classList.contains('source-token'));
       console.log('source token clicked', t);
       if (!t) return;
+      e.preventDefault();
       enterLinkingMode(t);
     });
 


### PR DESCRIPTION
## Summary
- Detect blanks and source tokens via `composedPath` so linking doesn't miss clicks
- Use `mousedown` handlers with `preventDefault` for reliable linking without losing focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7e3583988323aedb0b0f182c56a5