### PR TITLE
Fix answer bank targeting filled blanks

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -4804,7 +4804,7 @@
         if (empty) return empty;
         const incorrect = clean.find(inp => !inp.classList.contains('correct'));
         if (incorrect) return incorrect;
-        return clean[0];
+        return null;
       }
 
       function blankNeedsAnswer(input) {


### PR DESCRIPTION
## Summary
- update the blank selection helper so the answer bank stops targeting already completed blanks

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb5eb751fc8323996c16c249673343