### PR TITLE
Enable mobile answer bank for diagram quizzes

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -5594,6 +5594,18 @@
           if (sec.extraImages) {
             renderQuizExtras(sec, wrapper);
           }
+          if (document.body.classList.contains('mobile')) {
+            toggleAnswersBtn.style.display = 'inline-block';
+            if (answersVisible) {
+              buildAnswerBank(sec);
+              answerBank.style.display = 'block';
+              toggleAnswersBtn.textContent = 'Hide Answers';
+            } else {
+              answerBank.style.display = 'none';
+              answerBank.innerHTML = '';
+              toggleAnswersBtn.textContent = 'Show Answers';
+            }
+          }
           return;
         }
         // existing fill-in logic follows


### PR DESCRIPTION
## Summary
- expose the Show Answers toggle for diagram questions on mobile so the label blanks populate the answer bank like other quizzes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb8b26c2208323b2c8da2aad350528