### PR TITLE
Remove mobile home button display

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -717,6 +717,7 @@
     body.mobile:not(.quiz-active) #main { display: none; }
     body.mobile:not(.quiz-active) #mobileStart { display: block; }
     body.mobile.quiz-active #header { cursor: pointer; }
+    body.mobile #homeBtn { display: none !important; }
     /* Ensure quiz images scale to fit smaller screens (mobile only) */
     body.mobile #quizContent img {
       max-width: 100%;
@@ -2009,12 +2010,7 @@
           }
         }
         if (document.body.classList.contains('mobile')) {
-          const blanks = document.querySelectorAll('#quizContent input.blank-input');
-          if (quizOrder.length === 1 && blanks.length > 0) {
-            homeBtn.style.display = 'block';
-          } else {
-            homeBtn.style.display = 'none';
-          }
+          homeBtn.style.display = 'none';
         }
         updateProgressIndicator();
       }


### PR DESCRIPTION
## Summary
- hide the Home button on mobile so navigation relies on the header tap target
- prevent quiz completion logic from toggling the Home button back on during mobile sessions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf6f8b69988323a1c5ac4e822be392