### PR TITLE
Add What/How/Why sections to quiz data

### DIFF
--- a/quizData.json
+++ b/quizData.json
@@ -43,8 +43,8 @@
               "word": "ID"
             }
           ],
-          "rawHtml": "<p>Required to be PIC</p><p>\t◊ Pilot Certificate (61.3)</p><p>\t◊ Government Issued Photo ID (61.3)</p><p>\t◊ 18 Years old for commercial license (61.123)</p><p>\t◊ Medical Certificate (2nd class for commercial privileges) (61.23)</p><p>\t◊ Flight Review (Or Checkride) within 24 Calendar Months</p><p>Be familiar with all info concerning your flight prior to it. -&gt; NWKRAFT (91.103)</p>",
-          "rawText": "Required to be PIC\n\t◊ Pilot Certificate (61.3)\n\t◊ Government Issued Photo ID (61.3)\n\t◊ 18 Years old for commercial license (61.123)\n\t◊ Medical Certificate (2nd class for commercial privileges) (61.23)\n\t◊ Flight Review (Or Checkride) within 24 Calendar Months\nBe familiar with all info concerning your flight prior to it. -> NWKRAFT (91.103)\n"
+          "rawHtml": "<h3>What</h3><p>Required to be PIC</p><p>\t\u25ca Pilot Certificate (61.3)</p><p>\t\u25ca Government Issued Photo ID (61.3)</p><p>\t\u25ca 18 Years old for commercial license (61.123)</p><p>\t\u25ca Medical Certificate (2nd class for commercial privileges) (61.23)</p><p>\t\u25ca Flight Review (Or Checkride) within 24 Calendar Months</p><p>Be familiar with all info concerning your flight prior to it. -&gt; NWKRAFT (91.103)</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRequired to be PIC\n\t\u25ca Pilot Certificate (61.3)\n\t\u25ca Government Issued Photo ID (61.3)\n\t\u25ca 18 Years old for commercial license (61.123)\n\t\u25ca Medical Certificate (2nd class for commercial privileges) (61.23)\n\t\u25ca Flight Review (Or Checkride) within 24 Calendar Months\nBe familiar with all info concerning your flight prior to it. -> NWKRAFT (91.103)\n\nHow:\n\nWhy:\n"
         },
         {
           "alts": {},
@@ -118,8 +118,8 @@
               "word": "High"
             }
           ],
-          "rawHtml": "<p>Required Endorsements (61.31)</p><ul><li>Complex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller</li><li>High Performance - More than 200 Horsepower</li><li>Tailwheel - No Ground Instruction Required.</li><li>Towing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.</li><li>High Altitude - aircraft with above 25000 service ceiling or max operating altitude</li></ul>",
-          "rawText": "Required Endorsements (61.31)\nComplex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller\nHigh Performance - More than 200 Horsepower\nTailwheel - No Ground Instruction Required.\nTowing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.\nHigh Altitude - aircraft with above 25000 service ceiling or max operating altitude\n",
+          "rawHtml": "<h3>What</h3><p>Required Endorsements (61.31)</p><ul><li>Complex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller</li><li>High Performance - More than 200 Horsepower</li><li>Tailwheel - No Ground Instruction Required.</li><li>Towing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.</li><li>High Altitude - aircraft with above 25000 service ceiling or max operating altitude</li></ul><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRequired Endorsements (61.31)\nComplex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller\nHigh Performance - More than 200 Horsepower\nTailwheel - No Ground Instruction Required.\nTowing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.\nHigh Altitude - aircraft with above 25000 service ceiling or max operating altitude\n\nHow:\n\nWhy:\n",
           "title": "Required Aircraft Endorsements (61.31)",
           "type": "fill"
         },
@@ -183,8 +183,8 @@
               "word": "reputation"
             }
           ],
-          "rawHtml": "<p>Can fly for compensation or hire and can carry people or property for compensation or hire .</p><p>Need an Instrument Rating to fly people for compensation or hire on flight over 50 NM or at night .</p><p><br></p><p>Can Fly for hire for a commercial operator if you do not have operational control or you can fly under 119.1E Exceptions for hire</p><p>or you can fly under 91 for hire as long as the flying is incidental to the business and not the business itself. </p><p><br></p><p>Can't \"Hold Out\" - Advertise or build a reputation for flying the public.</p>",
-          "rawText": "Can fly for compensation or hire and can carry people or property for compensation or hire .\nNeed an Instrument Rating to fly people for compensation or hire on flight over 50 NM or at night .\n\nCan Fly for hire for a commercial operator if you do not have operational control or you can fly under 119.1E Exceptions for hire\nor you can fly under 91 for hire as long as the flying is incidental to the business and not the business itself. \n\nCan't \"Hold Out\" - Advertise or build a reputation for flying the public.\n",
+          "rawHtml": "<h3>What</h3><p>Can fly for compensation or hire and can carry people or property for compensation or hire .</p><p>Need an Instrument Rating to fly people for compensation or hire on flight over 50 NM or at night .</p><p><br></p><p>Can Fly for hire for a commercial operator if you do not have operational control or you can fly under 119.1E Exceptions for hire</p><p>or you can fly under 91 for hire as long as the flying is incidental to the business and not the business itself. </p><p><br></p><p>Can't \"Hold Out\" - Advertise or build a reputation for flying the public.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan fly for compensation or hire and can carry people or property for compensation or hire .\nNeed an Instrument Rating to fly people for compensation or hire on flight over 50 NM or at night .\n\nCan Fly for hire for a commercial operator if you do not have operational control or you can fly under 119.1E Exceptions for hire\nor you can fly under 91 for hire as long as the flying is incidental to the business and not the business itself. \n\nCan't \"Hold Out\" - Advertise or build a reputation for flying the public.\n\nHow:\n\nWhy:\n",
           "title": "Commercial Priveleges",
           "type": "fill"
         },
@@ -296,8 +296,8 @@
               "word": "Permit"
             }
           ],
-          "rawHtml": "<p>Required Aircraft Documents - ARROW  (91.203)</p><p>\t• Airworthiness Certificate - Visible to Passengers </p><p>\t• Registration Certificate - Expires every 7 years or if sold</p><p>\t• Radio Station License - For international Use - 10 year duration</p><p>\t• Operating Limitations - Placards, Markings, POH/AFM</p><p>\t• Weight and Balance Info - POH/AFM</p><p><br></p><p>Bonus - CAP</p><p>        • Compass Deviation Card</p><p>        • Avionics Reference Guide</p><p>        • Permit - Ferry / Special Flight Permit</p>",
-          "rawText": "Required Aircraft Documents - ARROW  (91.203)\n\t• Airworthiness Certificate - Visible to Passengers \n\t• Registration Certificate - Expires every 7 years or if sold\n\t• Radio Station License - For international Use - 10 year duration\n\t• Operating Limitations - Placards, Markings, POH/AFM\n\t• Weight and Balance Info - POH/AFM\n\nBonus - CAP\n        • Compass Deviation Card\n        • Avionics Reference Guide\n        • Permit - Ferry / Special Flight Permit\n",
+          "rawHtml": "<h3>What</h3><p>Required Aircraft Documents - ARROW  (91.203)</p><p>\t\u2022 Airworthiness Certificate - Visible to Passengers </p><p>\t\u2022 Registration Certificate - Expires every 7 years or if sold</p><p>\t\u2022 Radio Station License - For international Use - 10 year duration</p><p>\t\u2022 Operating Limitations - Placards, Markings, POH/AFM</p><p>\t\u2022 Weight and Balance Info - POH/AFM</p><p><br></p><p>Bonus - CAP</p><p>        \u2022 Compass Deviation Card</p><p>        \u2022 Avionics Reference Guide</p><p>        \u2022 Permit - Ferry / Special Flight Permit</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRequired Aircraft Documents - ARROW  (91.203)\n\t\u2022 Airworthiness Certificate - Visible to Passengers \n\t\u2022 Registration Certificate - Expires every 7 years or if sold\n\t\u2022 Radio Station License - For international Use - 10 year duration\n\t\u2022 Operating Limitations - Placards, Markings, POH/AFM\n\t\u2022 Weight and Balance Info - POH/AFM\n\nBonus - CAP\n        \u2022 Compass Deviation Card\n        \u2022 Avionics Reference Guide\n        \u2022 Permit - Ferry / Special Flight Permit\n\nHow:\n\nWhy:\n",
           "title": "Required Aircraft Documents - (91.203)"
         },
         {
@@ -336,8 +336,8 @@
               "word": "Category"
             }
           ],
-          "rawHtml": "<p>Carrying Passengers (61.57)</p><p>\t◊ 3 Takeoff and Landings</p><p>\t◊ Same Category and Class and Type if Required</p><p>\t◊ Within 90 Days</p><p>*To fly at night with passengers the landings have to be done between 1 Hour after sunset to 1 hour before sunrise to a full stop. </p>",
-          "rawText": "Carrying Passengers (61.57)\n\t◊ 3 Takeoff and Landings\n\t◊ Same Category and Class and Type if Required\n\t◊ Within 90 Days\n*To fly at night with passengers the landings have to be done between 1 Hour after sunset to 1 hour before sunrise to a full stop. \n",
+          "rawHtml": "<h3>What</h3><p>Carrying Passengers (61.57)</p><p>\t\u25ca 3 Takeoff and Landings</p><p>\t\u25ca Same Category and Class and Type if Required</p><p>\t\u25ca Within 90 Days</p><p>*To fly at night with passengers the landings have to be done between 1 Hour after sunset to 1 hour before sunrise to a full stop. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCarrying Passengers (61.57)\n\t\u25ca 3 Takeoff and Landings\n\t\u25ca Same Category and Class and Type if Required\n\t\u25ca Within 90 Days\n*To fly at night with passengers the landings have to be done between 1 Hour after sunset to 1 hour before sunrise to a full stop. \n\nHow:\n\nWhy:\n",
           "title": "Requirements to Carry Passengers (61.57)"
         },
         {
@@ -402,8 +402,8 @@
               "y": 12
             }
           ],
-          "rawHtml": "<p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>◊ Cancelled upon request</p><p>◊ Aircraft destroyed</p><p>◊ Ownership Transferred</p><p>◊ Owner loses citizenship</p><p>◊ Owner Dies</p>",
-          "rawText": "Can register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n◊ Cancelled upon request\n◊ Aircraft destroyed\n◊ Ownership Transferred\n◊ Owner loses citizenship\n◊ Owner Dies\n",
+          "rawHtml": "<h3>What</h3><p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>\u25ca Cancelled upon request</p><p>\u25ca Aircraft destroyed</p><p>\u25ca Ownership Transferred</p><p>\u25ca Owner loses citizenship</p><p>\u25ca Owner Dies</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n\u25ca Cancelled upon request\n\u25ca Aircraft destroyed\n\u25ca Ownership Transferred\n\u25ca Owner loses citizenship\n\u25ca Owner Dies\n\nHow:\n\nWhy:\n",
           "title": "Category | Class | Type",
           "type": "label"
         },
@@ -473,7 +473,7 @@
               ],
               "hideUntilSolved": true,
               "labelText": "60",
-              "rawText": "Statement of Demonstrated Ability (SODA) - Can be given if you have a condition that doesn’t change over time but would normally disqualify you like an amputation or hearing impairment. Doesn't Expire.\n\nSpecial Issuance Medical - Can be given if you have a condition that could get worse over time or flair back up like diabetes or previous substance abuse. Typically requires periodic reevaluations. "
+              "rawText": "Statement of Demonstrated Ability (SODA) - Can be given if you have a condition that doesn\u2019t change over time but would normally disqualify you like an amputation or hearing impairment. Doesn't Expire.\n\nSpecial Issuance Medical - Can be given if you have a condition that could get worse over time or flair back up like diabetes or previous substance abuse. Typically requires periodic reevaluations. "
             }
           ],
           "hidden": [],
@@ -560,8 +560,8 @@
               "y": 192
             }
           ],
-          "rawHtml": "<p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>◊ Cancelled upon request</p><p>◊ Aircraft destroyed</p><p>◊ Ownership Transferred</p><p>◊ Owner loses citizenship</p><p>◊ Owner Dies</p>",
-          "rawText": "Can register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n◊ Cancelled upon request\n◊ Aircraft destroyed\n◊ Ownership Transferred\n◊ Owner loses citizenship\n◊ Owner Dies\n",
+          "rawHtml": "<h3>What</h3><p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>\u25ca Cancelled upon request</p><p>\u25ca Aircraft destroyed</p><p>\u25ca Ownership Transferred</p><p>\u25ca Owner loses citizenship</p><p>\u25ca Owner Dies</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n\u25ca Cancelled upon request\n\u25ca Aircraft destroyed\n\u25ca Ownership Transferred\n\u25ca Owner loses citizenship\n\u25ca Owner Dies\n\nHow:\n\nWhy:\n",
           "title": "Medical Certificates",
           "type": "label"
         },
@@ -605,8 +605,8 @@
               "word": "all"
             }
           ],
-          "rawHtml": "<p>Required every 24 Calendar Months</p><p>Any checkride counts or some 121/135 proficiency checks</p><p>Can't fail a Flight Review it would just count as a training flight</p><p>Consists of a minimum of 1 hour ground and 1 hour flight to show general operating and flight rule knowledge and any maneuvers deemed necessary to safely fly.</p><p>Can be given by any CFI rated for that category and class and you must log the flight plus get an endorsement if you pass.</p><p>Any flight review covers all types of aircraft you are rated in.</p>",
-          "rawText": "Required every 24 Calendar Months\nAny checkride counts or some 121/135 proficiency checks\nCan't fail a Flight Review it would just count as a training flight\nConsists of a minimum of 1 hour ground and 1 hour flight to show general operating and flight rule knowledge and any maneuvers deemed necessary to safely fly.\nCan be given by any CFI rated for that category and class and you must log the flight plus get an endorsement if you pass.\nAny flight review covers all types of aircraft you are rated in.\n",
+          "rawHtml": "<h3>What</h3><p>Required every 24 Calendar Months</p><p>Any checkride counts or some 121/135 proficiency checks</p><p>Can't fail a Flight Review it would just count as a training flight</p><p>Consists of a minimum of 1 hour ground and 1 hour flight to show general operating and flight rule knowledge and any maneuvers deemed necessary to safely fly.</p><p>Can be given by any CFI rated for that category and class and you must log the flight plus get an endorsement if you pass.</p><p>Any flight review covers all types of aircraft you are rated in.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRequired every 24 Calendar Months\nAny checkride counts or some 121/135 proficiency checks\nCan't fail a Flight Review it would just count as a training flight\nConsists of a minimum of 1 hour ground and 1 hour flight to show general operating and flight rule knowledge and any maneuvers deemed necessary to safely fly.\nCan be given by any CFI rated for that category and class and you must log the flight plus get an endorsement if you pass.\nAny flight review covers all types of aircraft you are rated in.\n\nHow:\n\nWhy:\n",
           "title": "Flight Reviews",
           "type": "fill"
         },
@@ -702,8 +702,8 @@
               "word": "Incidental"
             }
           ],
-          "rawHtml": "<p>Commercial Regulations</p><p>\t◊ 119.1e - Exceptions like flight instructor - Don't need an AOC</p><p>\t◊ 91k - Fractional Ownership , Private Pilot Privileges - Incidental to the business don't need an AOC</p><p>\t◊ 121 - Consistently Scheduled routes , Airlines </p><p>\t◊ 125 - Big Planes , applied for operations with maximum payload over 6000 pounds or seating configuration of 20 or more passengers. </p><p>\t◊ 135 - Unscheduled , Charters</p>",
-          "rawText": "Commercial Regulations\n\t◊ 119.1e - Exceptions like flight instructor - Don't need an AOC\n\t◊ 91k - Fractional Ownership , Private Pilot Privileges - Incidental to the business don't need an AOC\n\t◊ 121 - Consistently Scheduled routes , Airlines \n\t◊ 125 - Big Planes , applied for operations with maximum payload over 6000 pounds or seating configuration of 20 or more passengers. \n\t◊ 135 - Unscheduled , Charters\n",
+          "rawHtml": "<h3>What</h3><p>Commercial Regulations</p><p>\t\u25ca 119.1e - Exceptions like flight instructor - Don't need an AOC</p><p>\t\u25ca 91k - Fractional Ownership , Private Pilot Privileges - Incidental to the business don't need an AOC</p><p>\t\u25ca 121 - Consistently Scheduled routes , Airlines </p><p>\t\u25ca 125 - Big Planes , applied for operations with maximum payload over 6000 pounds or seating configuration of 20 or more passengers. </p><p>\t\u25ca 135 - Unscheduled , Charters</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCommercial Regulations\n\t\u25ca 119.1e - Exceptions like flight instructor - Don't need an AOC\n\t\u25ca 91k - Fractional Ownership , Private Pilot Privileges - Incidental to the business don't need an AOC\n\t\u25ca 121 - Consistently Scheduled routes , Airlines \n\t\u25ca 125 - Big Planes , applied for operations with maximum payload over 6000 pounds or seating configuration of 20 or more passengers. \n\t\u25ca 135 - Unscheduled , Charters\n\nHow:\n\nWhy:\n",
           "type": "fill"
         },
         {
@@ -730,8 +730,8 @@
               "word": "Control"
             }
           ],
-          "rawHtml": "<p>Rule of Three\n\t◊ Operational Control - Authority over initiating, conducting, or terminating a flight. \n\t◊ PIC\n\t◊ Making Money \nCan have two of these three without anybody having an air operator certificate as long as its incidental to the business like the owner being flown around himself by a pilot to meetings or something but he can't sell those flights to other people. The flight itself can't be the business, but you can pay somebody to fly the plane. \n</p>",
-          "rawText": "Rule of Three\n\t◊ Operational Control - Authority over initiating, conducting, or terminating a flight. \n\t◊ PIC\n\t◊ Making Money \nCan have two of these three without anybody having an air operator certificate as long as its incidental to the business like the owner being flown around himself by a pilot to meetings or something but he can't sell those flights to other people. The flight itself can't be the business, but you can pay somebody to fly the plane. \n",
+          "rawHtml": "<h3>What</h3><p>Rule of Three\n\t\u25ca Operational Control - Authority over initiating, conducting, or terminating a flight. \n\t\u25ca PIC\n\t\u25ca Making Money \nCan have two of these three without anybody having an air operator certificate as long as its incidental to the business like the owner being flown around himself by a pilot to meetings or something but he can't sell those flights to other people. The flight itself can't be the business, but you can pay somebody to fly the plane. \n</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRule of Three\n\t\u25ca Operational Control - Authority over initiating, conducting, or terminating a flight. \n\t\u25ca PIC\n\t\u25ca Making Money \nCan have two of these three without anybody having an air operator certificate as long as its incidental to the business like the owner being flown around himself by a pilot to meetings or something but he can't sell those flights to other people. The flight itself can't be the business, but you can pay somebody to fly the plane. \n\nHow:\n\nWhy:\n",
           "type": "fill"
         },
         {
@@ -786,8 +786,8 @@
               "word": "compensation"
             }
           ],
-          "rawHtml": "<p>Common Carriage</p><p>  ◊ Holding out to transport people or property from place to place for compensation or hire. </p><p><br></p><p>Private Carriage</p><p>  ◊ Transporting people or property from place to place for compensation or hire.</p><p>Doesn't hold out and has only a few select long term customers - 3 or less, more than 18 is common and in between is gray area.</p>",
-          "rawText": "Common Carriage\n  ◊ Holding out to transport people or property from place to place for compensation or hire. \n\nPrivate Carriage\n  ◊ Transporting people or property from place to place for compensation or hire.\nDoesn't hold out and has only a few select long term customers - 3 or less, more than 18 is common and in between is gray area.\n",
+          "rawHtml": "<h3>What</h3><p>Common Carriage</p><p>  \u25ca Holding out to transport people or property from place to place for compensation or hire. </p><p><br></p><p>Private Carriage</p><p>  \u25ca Transporting people or property from place to place for compensation or hire.</p><p>Doesn't hold out and has only a few select long term customers - 3 or less, more than 18 is common and in between is gray area.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCommon Carriage\n  \u25ca Holding out to transport people or property from place to place for compensation or hire. \n\nPrivate Carriage\n  \u25ca Transporting people or property from place to place for compensation or hire.\nDoesn't hold out and has only a few select long term customers - 3 or less, more than 18 is common and in between is gray area.\n\nHow:\n\nWhy:\n",
           "title": "Common Carriage / Private Carriage",
           "type": "fill"
         },
@@ -803,8 +803,8 @@
               "word": "Days"
             }
           ],
-          "rawHtml": "<p>Change of Address (61.60)\nMust Notify FAA within 30 Days or can no longer use pilot privileges.\nCan login and update it instantly online through FAA website.\n</p>",
-          "rawText": "Change of Address (61.60)\nMust Notify FAA within 30 Days or can no longer use pilot privileges.\nCan login and update it instantly online through FAA website.\n",
+          "rawHtml": "<h3>What</h3><p>Change of Address (61.60)\nMust Notify FAA within 30 Days or can no longer use pilot privileges.\nCan login and update it instantly online through FAA website.\n</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nChange of Address (61.60)\nMust Notify FAA within 30 Days or can no longer use pilot privileges.\nCan login and update it instantly online through FAA website.\n\nHow:\n\nWhy:\n",
           "type": "fill"
         },
         {
@@ -860,8 +860,8 @@
               "word": "Above"
             }
           ],
-          "rawHtml": "<p>Transponder Requirements (91.215)</p><p>\t◊ Class A | B | and C</p><p>\t◊ Above Class B and C</p><p>\t◊ Mode C Veil - 30 NM around Class B .</p><p>\t◊ All Airspace at or above 10000 MSL - unless it's also at or below 2500 AGL. </p><p>*Since 2020 ADS-B Out is now required everywhere a Transponder is.</p>",
-          "rawText": "Transponder Requirements (91.215)\n\t◊ Class A | B | and C\n\t◊ Above Class B and C\n\t◊ Mode C Veil - 30 NM around Class B .\n\t◊ All Airspace at or above 10000 MSL - unless it's also at or below 2500 AGL. \n*Since 2020 ADS-B Out is now required everywhere a Transponder is.\n",
+          "rawHtml": "<h3>What</h3><p>Transponder Requirements (91.215)</p><p>\t\u25ca Class A | B | and C</p><p>\t\u25ca Above Class B and C</p><p>\t\u25ca Mode C Veil - 30 NM around Class B .</p><p>\t\u25ca All Airspace at or above 10000 MSL - unless it's also at or below 2500 AGL. </p><p>*Since 2020 ADS-B Out is now required everywhere a Transponder is.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTransponder Requirements (91.215)\n\t\u25ca Class A | B | and C\n\t\u25ca Above Class B and C\n\t\u25ca Mode C Veil - 30 NM around Class B .\n\t\u25ca All Airspace at or above 10000 MSL - unless it's also at or below 2500 AGL. \n*Since 2020 ADS-B Out is now required everywhere a Transponder is.\n\nHow:\n\nWhy:\n",
           "type": "fill"
         },
         {
@@ -1020,8 +1020,8 @@
               "y": 524
             }
           ],
-          "rawHtml": "<p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>◊ Cancelled upon request</p><p>◊ Aircraft destroyed</p><p>◊ Ownership Transferred</p><p>◊ Owner loses citizenship</p><p>◊ Owner Dies</p>",
-          "rawText": "Can register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n◊ Cancelled upon request\n◊ Aircraft destroyed\n◊ Ownership Transferred\n◊ Owner loses citizenship\n◊ Owner Dies\n",
+          "rawHtml": "<h3>What</h3><p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>\u25ca Cancelled upon request</p><p>\u25ca Aircraft destroyed</p><p>\u25ca Ownership Transferred</p><p>\u25ca Owner loses citizenship</p><p>\u25ca Owner Dies</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n\u25ca Cancelled upon request\n\u25ca Aircraft destroyed\n\u25ca Ownership Transferred\n\u25ca Owner loses citizenship\n\u25ca Owner Dies\n\nHow:\n\nWhy:\n",
           "title": "VFR Weather Minimums",
           "type": "label"
         },
@@ -1061,8 +1061,8 @@
               "word": "Information"
             }
           ],
-          "rawHtml": "<p>FAA / Manufacturer Aircraft Notices</p><p><br></p><p>Special Airworthiness Information Bulletin (SAIB) - FAA Recommendations to improve the safety of a product, doesn't currently meet the requirements of an AD but can still become one.</p><p><br></p><p>Service Bulletins - Manufacturer posts best practice advice but not yet mandatory </p><p><br></p>",
-          "rawText": "FAA / Manufacturer Aircraft Notices\n\nSpecial Airworthiness Information Bulletin (SAIB) - FAA Recommendations to improve the safety of a product, doesn't currently meet the requirements of an AD but can still become one.\n\nService Bulletins - Manufacturer posts best practice advice but not yet mandatory \n\n",
+          "rawHtml": "<h3>What</h3><p>FAA / Manufacturer Aircraft Notices</p><p><br></p><p>Special Airworthiness Information Bulletin (SAIB) - FAA Recommendations to improve the safety of a product, doesn't currently meet the requirements of an AD but can still become one.</p><p><br></p><p>Service Bulletins - Manufacturer posts best practice advice but not yet mandatory </p><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nFAA / Manufacturer Aircraft Notices\n\nSpecial Airworthiness Information Bulletin (SAIB) - FAA Recommendations to improve the safety of a product, doesn't currently meet the requirements of an AD but can still become one.\n\nService Bulletins - Manufacturer posts best practice advice but not yet mandatory \n\nHow:\n\nWhy:\n",
           "title": "SAIB / SB",
           "type": "fill"
         },
@@ -1106,8 +1106,8 @@
               "word": "12500"
             }
           ],
-          "rawHtml": "<p>BasicMed</p><p>Maximum Certified Takeoff Weight: 12500 pounds</p><p>Maximum 7 total Occupants, 6 total passengers</p><p>Maximum Altitude 18000 feet</p><p>Maximum Airspeed 250 Knots</p><p>Can't operate for compensation or hire except flight instruction</p><p>To get it you need to take an online course every 24 Months and a medical exam every 48 months</p>",
-          "rawText": "BasicMed\nMaximum Certified Takeoff Weight: 12500 pounds\nMaximum 7 total Occupants, 6 total passengers\nMaximum Altitude 18000 feet\nMaximum Airspeed 250 Knots\nCan't operate for compensation or hire except flight instruction\nTo get it you need to take an online course every 24 Months and a medical exam every 48 months\n",
+          "rawHtml": "<h3>What</h3><p>BasicMed</p><p>Maximum Certified Takeoff Weight: 12500 pounds</p><p>Maximum 7 total Occupants, 6 total passengers</p><p>Maximum Altitude 18000 feet</p><p>Maximum Airspeed 250 Knots</p><p>Can't operate for compensation or hire except flight instruction</p><p>To get it you need to take an online course every 24 Months and a medical exam every 48 months</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nBasicMed\nMaximum Certified Takeoff Weight: 12500 pounds\nMaximum 7 total Occupants, 6 total passengers\nMaximum Altitude 18000 feet\nMaximum Airspeed 250 Knots\nCan't operate for compensation or hire except flight instruction\nTo get it you need to take an online course every 24 Months and a medical exam every 48 months\n\nHow:\n\nWhy:\n",
           "type": "fill"
         },
         {
@@ -1174,8 +1174,8 @@
               "word": "Minimum"
             }
           ],
-          "rawHtml": "<p>Make sure the equipment is not in reg on its TCDS.</p><p>If your aircraft has a Minimum Equipment list start there - Must be onboard aircraft.</p><p>Created from a MMEL - Master minimum Equipment List | General for type of aircraft</p><p>Next refer to the KOEL - Kinds of Operation Equipment List. Has different categories like day and night operations.</p><p>Then look at the Regulations like 91.205</p><p>Make sure there aren't any Airworthiness Directives requiring it. </p><p>Finally make sure you are comfortable flying without it.</p><p>The Inop Equipment must be at least either inspected, replaced, repaired, or removed at the next inspection. </p>",
-          "rawText": "Make sure the equipment is not in reg on its TCDS.\nIf your aircraft has a Minimum Equipment list start there - Must be onboard aircraft.\nCreated from a MMEL - Master minimum Equipment List | General for type of aircraft\nNext refer to the KOEL - Kinds of Operation Equipment List. Has different categories like day and night operations.\nThen look at the Regulations like 91.205\nMake sure there aren't any Airworthiness Directives requiring it. \nFinally make sure you are comfortable flying without it.\nThe Inop Equipment must be at least either inspected, replaced, repaired, or removed at the next inspection. \n",
+          "rawHtml": "<h3>What</h3><p>Make sure the equipment is not in reg on its TCDS.</p><p>If your aircraft has a Minimum Equipment list start there - Must be onboard aircraft.</p><p>Created from a MMEL - Master minimum Equipment List | General for type of aircraft</p><p>Next refer to the KOEL - Kinds of Operation Equipment List. Has different categories like day and night operations.</p><p>Then look at the Regulations like 91.205</p><p>Make sure there aren't any Airworthiness Directives requiring it. </p><p>Finally make sure you are comfortable flying without it.</p><p>The Inop Equipment must be at least either inspected, replaced, repaired, or removed at the next inspection. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nMake sure the equipment is not in reg on its TCDS.\nIf your aircraft has a Minimum Equipment list start there - Must be onboard aircraft.\nCreated from a MMEL - Master minimum Equipment List | General for type of aircraft\nNext refer to the KOEL - Kinds of Operation Equipment List. Has different categories like day and night operations.\nThen look at the Regulations like 91.205\nMake sure there aren't any Airworthiness Directives requiring it. \nFinally make sure you are comfortable flying without it.\nThe Inop Equipment must be at least either inspected, replaced, repaired, or removed at the next inspection. \n\nHow:\n\nWhy:\n",
           "title": "Inop Equipment Flow",
           "type": "fill"
         },
@@ -1215,8 +1215,8 @@
               "word": "passengers"
             }
           ],
-          "rawHtml": "<p>You can apply for one at your FSDO </p><p>Allows you to fly an aircraft that wouldn't otherwise meet airworthiness standards . </p><p>Examples: Fly to overdue maintenance | Evacuate from weather | Flight Test</p><p>Restrictions: Can't fly passengers also typically has bonus limitations like Day VMC only, No over flying congested areas, only valid one flight. </p>",
-          "rawText": "You can apply for one at your FSDO \nAllows you to fly an aircraft that wouldn't otherwise meet airworthiness standards . \nExamples: Fly to overdue maintenance | Evacuate from weather | Flight Test\nRestrictions: Can't fly passengers also typically has bonus limitations like Day VMC only, No over flying congested areas, only valid one flight. \n",
+          "rawHtml": "<h3>What</h3><p>You can apply for one at your FSDO </p><p>Allows you to fly an aircraft that wouldn't otherwise meet airworthiness standards . </p><p>Examples: Fly to overdue maintenance | Evacuate from weather | Flight Test</p><p>Restrictions: Can't fly passengers also typically has bonus limitations like Day VMC only, No over flying congested areas, only valid one flight. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYou can apply for one at your FSDO \nAllows you to fly an aircraft that wouldn't otherwise meet airworthiness standards . \nExamples: Fly to overdue maintenance | Evacuate from weather | Flight Test\nRestrictions: Can't fly passengers also typically has bonus limitations like Day VMC only, No over flying congested areas, only valid one flight. \n\nHow:\n\nWhy:\n",
           "title": "Special Flight Permit (Ferry)",
           "type": "fill"
         },
@@ -1291,8 +1291,8 @@
             }
           ],
           "hidden": [],
-          "rawHtml": "<p>Required Endorsements (61.31)</p><ul><li>Complex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller</li><li>High Performance - More than 200 Horsepower</li><li>Tailwheel - No Ground Instruction Required.</li><li>Towing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.</li><li>High Altitude - above 25000 service ceiling </li></ul>",
-          "rawText": "Required Endorsements (61.31)\nComplex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller\nHigh Performance - More than 200 Horsepower\nTailwheel - No Ground Instruction Required.\nTowing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.\nHigh Altitude - above 25000 service ceiling \n",
+          "rawHtml": "<h3>What</h3><p>Required Endorsements (61.31)</p><ul><li>Complex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller</li><li>High Performance - More than 200 Horsepower</li><li>Tailwheel - No Ground Instruction Required.</li><li>Towing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.</li><li>High Altitude - above 25000 service ceiling </li></ul><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRequired Endorsements (61.31)\nComplex Aircraft - Retractable Landing Gear | Flaps | Controllable Propeller\nHigh Performance - More than 200 Horsepower\nTailwheel - No Ground Instruction Required.\nTowing - Also need at least 100 hours PIC in Cat and Class and 3 actual or simulated glider tows within last 24 months.\nHigh Altitude - above 25000 service ceiling \n\nHow:\n\nWhy:\n",
           "type": "acronym"
         },
         {
@@ -1326,8 +1326,8 @@
             }
           ],
           "hidden": [],
-          "rawHtml": "<p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>◊ Cancelled upon request</p><p>◊ Aircraft destroyed</p><p>◊ Ownership Transferred</p><p>◊ Owner loses citizenship</p><p>◊ Owner Dies</p>",
-          "rawText": "Can register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n◊ Cancelled upon request\n◊ Aircraft destroyed\n◊ Ownership Transferred\n◊ Owner loses citizenship\n◊ Owner Dies\n",
+          "rawHtml": "<h3>What</h3><p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>\u25ca Cancelled upon request</p><p>\u25ca Aircraft destroyed</p><p>\u25ca Ownership Transferred</p><p>\u25ca Owner loses citizenship</p><p>\u25ca Owner Dies</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n\u25ca Cancelled upon request\n\u25ca Aircraft destroyed\n\u25ca Ownership Transferred\n\u25ca Owner loses citizenship\n\u25ca Owner Dies\n\nHow:\n\nWhy:\n",
           "type": "acronym"
         },
         {
@@ -1358,8 +1358,8 @@
               "word": "Operator"
             }
           ],
-          "rawHtml": "<p>A plane is airworthy if it conforms to it's original type design and is in condition for safe flight</p><p>with all needed documents, inspections, and equipment. </p><p><br></p><p>It is the responsibility of the Owner / Operator to maintain it in airworthy conditions with proper maintenance records.</p>",
-          "rawText": "A plane is airworthy if it conforms to it's original type design and is in condition for safe flight\nwith all needed documents, inspections, and equipment. \n\nIt is the responsibility of the Owner / Operator to maintain it in airworthy conditions with proper maintenance records.\n",
+          "rawHtml": "<h3>What</h3><p>A plane is airworthy if it conforms to it's original type design and is in condition for safe flight</p><p>with all needed documents, inspections, and equipment. </p><p><br></p><p>It is the responsibility of the Owner / Operator to maintain it in airworthy conditions with proper maintenance records.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nA plane is airworthy if it conforms to it's original type design and is in condition for safe flight\nwith all needed documents, inspections, and equipment. \n\nIt is the responsibility of the Owner / Operator to maintain it in airworthy conditions with proper maintenance records.\n\nHow:\n\nWhy:\n",
           "type": "fill",
           "title": "Aircraft Airworthiness"
         },
@@ -1400,8 +1400,8 @@
               "word": "Dies"
             }
           ],
-          "rawHtml": "<p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>◊ Cancelled upon request</p><p>◊ Aircraft destroyed</p><p>◊ Ownership Transferred</p><p>◊ Owner loses citizenship</p><p>◊ Owner Dies</p>",
-          "rawText": "Can register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n◊ Cancelled upon request\n◊ Aircraft destroyed\n◊ Ownership Transferred\n◊ Owner loses citizenship\n◊ Owner Dies\n",
+          "rawHtml": "<h3>What</h3><p>Can register a plane through FAA.gov or local FSDO</p><p>Without being fully registered and use having the application forms you can operate for 12 months and can only fly domestically</p><p>A Registration loses its validity if -</p><p>\u25ca Cancelled upon request</p><p>\u25ca Aircraft destroyed</p><p>\u25ca Ownership Transferred</p><p>\u25ca Owner loses citizenship</p><p>\u25ca Owner Dies</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan register a plane through FAA.gov or local FSDO\nWithout being fully registered and use having the application forms you can operate for 12 months and can only fly domestically\nA Registration loses its validity if -\n\u25ca Cancelled upon request\n\u25ca Aircraft destroyed\n\u25ca Ownership Transferred\n\u25ca Owner loses citizenship\n\u25ca Owner Dies\n\nHow:\n\nWhy:\n",
           "title": "Aircraft Registration",
           "type": "fill"
         },
@@ -1421,8 +1421,8 @@
               "word": "10"
             }
           ],
-          "rawHtml": "<p>The Radio Station License is required for the aircraft and is valid for 10 years.</p><p>The Radio Operators Permit is required for the pilot and valid indefinitely.</p><p><br></p><p>The pilot can obtain his at FCC.gov by filling in a form and paying a small fee.</p>",
-          "rawText": "The Radio Station License is required for the aircraft and is valid for 10 years.\nThe Radio Operators Permit is required for the pilot and valid indefinitely.\n\nThe pilot can obtain his at FCC.gov by filling in a form and paying a small fee.\n",
+          "rawHtml": "<h3>What</h3><p>The Radio Station License is required for the aircraft and is valid for 10 years.</p><p>The Radio Operators Permit is required for the pilot and valid indefinitely.</p><p><br></p><p>The pilot can obtain his at FCC.gov by filling in a form and paying a small fee.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nThe Radio Station License is required for the aircraft and is valid for 10 years.\nThe Radio Operators Permit is required for the pilot and valid indefinitely.\n\nThe pilot can obtain his at FCC.gov by filling in a form and paying a small fee.\n\nHow:\n\nWhy:\n",
           "title": "Radio Licenses (International)",
           "type": "fill"
         },
@@ -1478,8 +1478,8 @@
               "word": "Immediate"
             }
           ],
-          "rawHtml": "<p><strong style=\"color: rgb(230, 0, 0);\">91.417 39</strong></p><p>Legally enforceable, issued by the <strong><em>FAA</em></strong> to correct an unsafe condition in an aircraft product.</p><p>Type of ADs -</p><ul><li>One Time - One time modification</li><li>Recurring - Repeated checks or replacements</li><li>Emergency - Requires Immediate action</li><li>Time Limited - Can wait a certain # of Tach Hours or until next inspection</li><li>Conditional - Required if a specific thing happens like a prop strike</li></ul>",
-          "rawText": "91.417 39\nLegally enforceable, issued by the FAA to correct an unsafe condition in an aircraft product.\nType of ADs -\nOne Time - One time modification\nRecurring - Repeated checks or replacements\nEmergency - Requires Immediate action\nTime Limited - Can wait a certain # of Tach Hours or until next inspection\nConditional - Required if a specific thing happens like a prop strike\n",
+          "rawHtml": "<h3>What</h3><p><strong style=\"color: rgb(230, 0, 0);\">91.417 39</strong></p><p>Legally enforceable, issued by the <strong><em>FAA</em></strong> to correct an unsafe condition in an aircraft product.</p><p>Type of ADs -</p><ul><li>One Time - One time modification</li><li>Recurring - Repeated checks or replacements</li><li>Emergency - Requires Immediate action</li><li>Time Limited - Can wait a certain # of Tach Hours or until next inspection</li><li>Conditional - Required if a specific thing happens like a prop strike</li></ul><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n91.417 39\nLegally enforceable, issued by the FAA to correct an unsafe condition in an aircraft product.\nType of ADs -\nOne Time - One time modification\nRecurring - Repeated checks or replacements\nEmergency - Requires Immediate action\nTime Limited - Can wait a certain # of Tach Hours or until next inspection\nConditional - Required if a specific thing happens like a prop strike\n\nHow:\n\nWhy:\n",
           "title": "Airworthiness Directives",
           "type": "fill"
         },
@@ -1507,8 +1507,8 @@
               "word": "10"
             }
           ],
-          "rawHtml": "<p>No difference in the inspection itself</p><p>Annuals need an A&amp;P with Inspection Authorization (IA)</p><p>100 Hours only need an A&amp;P</p><p>Annuals are certified as the Aircraft as a whole was inspected while</p><p>100 Hours should have a separate certification for each Airframe, Engine, and Prop</p><p>100 Hour be overflown by 10 hours to get to inspection location but counts for the next 100 hours</p><p>An annual can count as your 100 Hour but not the other way around</p>",
-          "rawText": "No difference in the inspection itself\nAnnuals need an A&P with Inspection Authorization (IA)\n100 Hours only need an A&P\nAnnuals are certified as the Aircraft as a whole was inspected while\n100 Hours should have a separate certification for each Airframe, Engine, and Prop\n100 Hour be overflown by 10 hours to get to inspection location but counts for the next 100 hours\nAn annual can count as your 100 Hour but not the other way around\n",
+          "rawHtml": "<h3>What</h3><p>No difference in the inspection itself</p><p>Annuals need an A&amp;P with Inspection Authorization (IA)</p><p>100 Hours only need an A&amp;P</p><p>Annuals are certified as the Aircraft as a whole was inspected while</p><p>100 Hours should have a separate certification for each Airframe, Engine, and Prop</p><p>100 Hour be overflown by 10 hours to get to inspection location but counts for the next 100 hours</p><p>An annual can count as your 100 Hour but not the other way around</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nNo difference in the inspection itself\nAnnuals need an A&P with Inspection Authorization (IA)\n100 Hours only need an A&P\nAnnuals are certified as the Aircraft as a whole was inspected while\n100 Hours should have a separate certification for each Airframe, Engine, and Prop\n100 Hour be overflown by 10 hours to get to inspection location but counts for the next 100 hours\nAn annual can count as your 100 Hour but not the other way around\n\nHow:\n\nWhy:\n",
           "title": "100 Hour vs Annual",
           "type": "fill"
         },
@@ -1544,8 +1544,8 @@
               "word": "first"
             }
           ],
-          "rawHtml": "<p>Can Operate without one for training operations within 50 NM and for 90 days after its been removed for maintenance. </p><p>We have a digital 406 ELT that also broadcasts on 121.5 which sends digital signals with more precise information, instead of just an analog one on 121.5.</p><p>Can be Tested during the first 5 minutes of the hour for a max of three sweeps.</p><p>Required to be toward the back of the tail cone to survive a crash.</p><p><em>I</em><strong><em>s</em></strong> activated by rapid deceleration or the switch.</p>",
-          "rawText": "Can Operate without one for training operations within 50 NM and for 90 days after its been removed for maintenance. \nWe have a digital 406 ELT that also broadcasts on 121.5 which sends digital signals with more precise information, instead of just an analog one on 121.5.\nCan be Tested during the first 5 minutes of the hour for a max of three sweeps.\nRequired to be toward the back of the tail cone to survive a crash.\nIs activated by rapid deceleration or the switch.\n",
+          "rawHtml": "<h3>What</h3><p>Can Operate without one for training operations within 50 NM and for 90 days after its been removed for maintenance. </p><p>We have a digital 406 ELT that also broadcasts on 121.5 which sends digital signals with more precise information, instead of just an analog one on 121.5.</p><p>Can be Tested during the first 5 minutes of the hour for a max of three sweeps.</p><p>Required to be toward the back of the tail cone to survive a crash.</p><p><em>I</em><strong><em>s</em></strong> activated by rapid deceleration or the switch.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan Operate without one for training operations within 50 NM and for 90 days after its been removed for maintenance. \nWe have a digital 406 ELT that also broadcasts on 121.5 which sends digital signals with more precise information, instead of just an analog one on 121.5.\nCan be Tested during the first 5 minutes of the hour for a max of three sweeps.\nRequired to be toward the back of the tail cone to survive a crash.\nIs activated by rapid deceleration or the switch.\n\nHow:\n\nWhy:\n",
           "title": "Emergency Locator Transmitter (ELT)",
           "type": "fill"
         },
@@ -1573,31 +1573,31 @@
               "word": "43"
             }
           ],
-          "rawHtml": "<p><strong><em>Part 43</em></strong></p><p>Preventative Maintenance can be performed by an owner / operator that holds at least a private pilot license.</p><p>Defined as simple or minor preservation operations or the replacement of small standard parts not involving complex assembly.</p><p>Anything not in part 43 appendix A paragraph C is not preventative maintenance,</p><p>However things like adding oil or adding air to tires is considered basic upkeep and not listed as preventative maintenance.</p><p>Must log work - Description | Date | Name, Signature, Cert Number, and kind of Cert for the person who did the work.</p>",
-          "rawText": "Part 43\nPreventative Maintenance can be performed by an owner / operator that holds at least a private pilot license.\nDefined as simple or minor preservation operations or the replacement of small standard parts not involving complex assembly.\nAnything not in part 43 appendix A paragraph C is not preventative maintenance,\nHowever things like adding oil or adding air to tires is considered basic upkeep and not listed as preventative maintenance.\nMust log work - Description | Date | Name, Signature, Cert Number, and kind of Cert for the person who did the work.\n",
+          "rawHtml": "<h3>What</h3><p><strong><em>Part 43</em></strong></p><p>Preventative Maintenance can be performed by an owner / operator that holds at least a private pilot license.</p><p>Defined as simple or minor preservation operations or the replacement of small standard parts not involving complex assembly.</p><p>Anything not in part 43 appendix A paragraph C is not preventative maintenance,</p><p>However things like adding oil or adding air to tires is considered basic upkeep and not listed as preventative maintenance.</p><p>Must log work - Description | Date | Name, Signature, Cert Number, and kind of Cert for the person who did the work.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPart 43\nPreventative Maintenance can be performed by an owner / operator that holds at least a private pilot license.\nDefined as simple or minor preservation operations or the replacement of small standard parts not involving complex assembly.\nAnything not in part 43 appendix A paragraph C is not preventative maintenance,\nHowever things like adding oil or adding air to tires is considered basic upkeep and not listed as preventative maintenance.\nMust log work - Description | Date | Name, Signature, Cert Number, and kind of Cert for the person who did the work.\n\nHow:\n\nWhy:\n",
           "title": "Preventative Maintenance",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>A list of equipment that is not required to fly the aircraft.</p><p>Specific to each individual aircraft and based on an MMEL.</p><p>Can obtained at an FSDO and will need to get a Letter of Authorization (LOA)</p><p>with it which goes in the MEL.</p>",
-          "rawText": "",
+          "rawHtml": "<h3>What</h3><p>A list of equipment that is not required to fly the aircraft.</p><p>Specific to each individual aircraft and based on an MMEL.</p><p>Can obtained at an FSDO and will need to get a Letter of Authorization (LOA)</p><p>with it which goes in the MEL.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Minimum Equipment List",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Required for major alterations to the airframe or systems.</p>",
-          "rawText": "",
+          "rawHtml": "<h3>What</h3><p>Required for major alterations to the airframe or systems.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Supplemental Type Certificate",
           "type": "fill"
         },
         {
           "hidden": [],
-          "rawHtml": "<h4><br></h4><p>Annual Inspection</p><p><br></p><p>Airworthiness Directives</p><p><em>   Published by FAA and are Mandatory</em></p><p>VOR Equipment</p><ul><li><em>Required for IFR - 30 Days</em></li></ul><p>100 Hour</p><ul><li><em>Required for Hire</em></li></ul><p>Altimeter and Static </p><ul><li><em>Required for IFR - 24 Months</em></li></ul><p>Transponder</p><ul><li><em>24 Months</em></li></ul><p>ELT</p><ul><li><em>&lt; 50% Battery | 1 hour cumulative use | 12 Months. Can be used within 50NM for 90 days after removal.</em></li></ul>",
-          "rawText": "\nAnnual Inspection\n\nAirworthiness Directives\n   Published by FAA and are Mandatory\nVOR Equipment\nRequired for IFR - 30 Days\n100 Hour\nRequired for Hire\nAltimeter and Static \nRequired for IFR - 24 Months\nTransponder\n24 Months\nELT\n< 50% Battery | 1 hour cumulative use | 12 Months. Can be used within 50NM for 90 days after removal.\n",
+          "rawHtml": "<h3>What</h3><h4><br></h4><p>Annual Inspection</p><p><br></p><p>Airworthiness Directives</p><p><em>   Published by FAA and are Mandatory</em></p><p>VOR Equipment</p><ul><li><em>Required for IFR - 30 Days</em></li></ul><p>100 Hour</p><ul><li><em>Required for Hire</em></li></ul><p>Altimeter and Static </p><ul><li><em>Required for IFR - 24 Months</em></li></ul><p>Transponder</p><ul><li><em>24 Months</em></li></ul><p>ELT</p><ul><li><em>&lt; 50% Battery | 1 hour cumulative use | 12 Months. Can be used within 50NM for 90 days after removal.</em></li></ul><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n\nAnnual Inspection\n\nAirworthiness Directives\n   Published by FAA and are Mandatory\nVOR Equipment\nRequired for IFR - 30 Days\n100 Hour\nRequired for Hire\nAltimeter and Static \nRequired for IFR - 24 Months\nTransponder\n24 Months\nELT\n< 50% Battery | 1 hour cumulative use | 12 Months. Can be used within 50NM for 90 days after removal.\n\nHow:\n\nWhy:\n",
           "title": "AVVIATE",
           "type": "fill"
         }
@@ -1658,7 +1658,7 @@
               "y": 435
             }
           ],
-          "rawHtml": "<p><br></p>",
+          "rawHtml": "<h3>What</h3><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
           "rawText": "\n",
           "title": "Camber / Chord Lines",
           "type": "label"
@@ -1672,7 +1672,7 @@
           "imgHeight": 522,
           "imgWidth": 717,
           "labels": [],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Axis",
           "type": "label"
         },
@@ -1739,7 +1739,7 @@
               "y": 83
             }
           ],
-          "rawHtml": "<p><br></p>",
+          "rawHtml": "<h3>What</h3><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
           "rawText": "\n",
           "title": "Adverse Yaw",
           "type": "label"
@@ -1824,7 +1824,7 @@
               "y": 462
             }
           ],
-          "rawHtml": "<p><br></p>",
+          "rawHtml": "<h3>What</h3><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
           "rawText": "\n",
           "title": "Ailerons",
           "type": "label"
@@ -1849,8 +1849,8 @@
               "word": "Ground"
             }
           ],
-          "rawHtml": "<p>Servo Trim Tabs -  172s has these which mean the trim tab moves the opposite direction of the elevator.</p><p>If you trim up it causes the elevator to be pushed down so you don't have to hold it down your self. </p><p><br></p><p>Ground Adjustable Tab - There is also a small tab on the rudder which is just a piece of metal you can bend by hand</p><p>to make sure the plane flies coordinated in level flight. </p>",
-          "rawText": "Servo Trim Tabs -  172s has these which mean the trim tab moves the opposite direction of the elevator.\nIf you trim up it causes the elevator to be pushed down so you don't have to hold it down your self. \n\nGround Adjustable Tab - There is also a small tab on the rudder which is just a piece of metal you can bend by hand\nto make sure the plane flies coordinated in level flight. \n",
+          "rawHtml": "<h3>What</h3><p>Servo Trim Tabs -  172s has these which mean the trim tab moves the opposite direction of the elevator.</p><p>If you trim up it causes the elevator to be pushed down so you don't have to hold it down your self. </p><p><br></p><p>Ground Adjustable Tab - There is also a small tab on the rudder which is just a piece of metal you can bend by hand</p><p>to make sure the plane flies coordinated in level flight. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nServo Trim Tabs -  172s has these which mean the trim tab moves the opposite direction of the elevator.\nIf you trim up it causes the elevator to be pushed down so you don't have to hold it down your self. \n\nGround Adjustable Tab - There is also a small tab on the rudder which is just a piece of metal you can bend by hand\nto make sure the plane flies coordinated in level flight. \n\nHow:\n\nWhy:\n",
           "title": "Trim",
           "type": "fill"
         },
@@ -1926,8 +1926,8 @@
               "word": "drag."
             }
           ],
-          "rawHtml": "<p>We have Electrically operated single slot flaps with 10, 20 and 30 degrees.</p><p>Single Slot Flaps - This means there is a gap that opens up between the wing and flap</p><p>which allows air from the below the wing to come up and reenergize the boundary layer between the air and wing,</p><p>this delays airflow separation and maintains that smooth laminar flow. </p><p><br></p><p>Flaps purpose is to produce more lift at a given AoA, produce more drag, and reduce landing roll.</p><p>Extra lift is produced by the new camber line, and the drag is beneficial in descending steeper without increasing airspeed.</p><p>The first 10 degrees of flaps primarily increases lift, and any more flaps produces much more drag. </p>",
-          "rawText": "We have Electrically operated single slot flaps with 10, 20 and 30 degrees.\nSingle Slot Flaps - This means there is a gap that opens up between the wing and flap\nwhich allows air from the below the wing to come up and reenergize the boundary layer between the air and wing,\nthis delays airflow separation and maintains that smooth laminar flow. \n\nFlaps purpose is to produce more lift at a given AoA, produce more drag, and reduce landing roll.\nExtra lift is produced by the new camber line, and the drag is beneficial in descending steeper without increasing airspeed.\nThe first 10 degrees of flaps primarily increases lift, and any more flaps produces much more drag. \n",
+          "rawHtml": "<h3>What</h3><p>We have Electrically operated single slot flaps with 10, 20 and 30 degrees.</p><p>Single Slot Flaps - This means there is a gap that opens up between the wing and flap</p><p>which allows air from the below the wing to come up and reenergize the boundary layer between the air and wing,</p><p>this delays airflow separation and maintains that smooth laminar flow. </p><p><br></p><p>Flaps purpose is to produce more lift at a given AoA, produce more drag, and reduce landing roll.</p><p>Extra lift is produced by the new camber line, and the drag is beneficial in descending steeper without increasing airspeed.</p><p>The first 10 degrees of flaps primarily increases lift, and any more flaps produces much more drag. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWe have Electrically operated single slot flaps with 10, 20 and 30 degrees.\nSingle Slot Flaps - This means there is a gap that opens up between the wing and flap\nwhich allows air from the below the wing to come up and reenergize the boundary layer between the air and wing,\nthis delays airflow separation and maintains that smooth laminar flow. \n\nFlaps purpose is to produce more lift at a given AoA, produce more drag, and reduce landing roll.\nExtra lift is produced by the new camber line, and the drag is beneficial in descending steeper without increasing airspeed.\nThe first 10 degrees of flaps primarily increases lift, and any more flaps produces much more drag. \n\nHow:\n\nWhy:\n",
           "title": "Flaps",
           "type": "fill"
         },
@@ -1947,8 +1947,8 @@
               "word": "strength"
             }
           ],
-          "rawHtml": "<p><strong>Corrugation is what it's called when the metal of the control surfaces is bent into diamond shapes.</strong></p><p><strong>It simply increases the structural strength of the metal.</strong></p>",
-          "rawText": "Corrugation is what it's called when the metal of the control surfaces is bent into diamond shapes.\nIt simply increases the structural strength of the metal.\n",
+          "rawHtml": "<h3>What</h3><p><strong>Corrugation is what it's called when the metal of the control surfaces is bent into diamond shapes.</strong></p><p><strong>It simply increases the structural strength of the metal.</strong></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCorrugation is what it's called when the metal of the control surfaces is bent into diamond shapes.\nIt simply increases the structural strength of the metal.\n\nHow:\n\nWhy:\n",
           "title": "Corrugation",
           "type": "fill"
         },
@@ -2012,23 +2012,23 @@
               "word": "descents"
             }
           ],
-          "rawHtml": "<p>Four Left Turning Tendencies</p><p><strong>1:</strong> Torque Effect - Newtons Third Law = Every action has an equal and opposite reaction.</p><p>The action of the propeller spinning clockwise makes the aircraft roll in the opposite direction to the left. Worse at high power settings but engine is offset to counteract this.</p><p><strong>2:</strong> <span class=\"popup-word\">*Gyroscopic Precession</span> - When you pitch up force is applied to the bottom of the spinning propeller,</p><p>this then actually gets applied 90 degrees into the turn later which actually pushes the nose to the right,</p><p>It is only a left turning tendency in descents and actually counteracts some of the others, in tail draggers you pitch down to land so it add to them.</p>",
-          "rawText": "Four Left Turning Tendencies\n1: Torque Effect - Newtons Third Law = Every action has an equal and opposite reaction.\nThe action of the propeller spinning clockwise makes the aircraft roll in the opposite direction to the left. Worse at high power settings but engine is offset to counteract this.\n2: P Factor - In High angles of attack the downward moving blade is facing into the wind more so it has a higher angle of attack also.\nThis means it's generating more thrust on the right downward moving side generating more thrust and making a yaw to the left.\n3: Spiraling Slipstream - At High power settings and low airspeeds the wind from the propeller spirals around the plane.\nThis eventually hits the vertical stabilizer on the left side pushing it creating a yaw to the left.\n4: *Gyroscopic Precession - When you pitch up force is applied to the bottom of the spinning propeller,\nthis then actually gets applied 90 degrees into the turn later which actually pushes the nose to the right,\nIt is only a left turning tendency in descents and actually counteracts some of the others, in tail draggers you pitch down to land so it add to them.\n",
+          "rawHtml": "<h3>What</h3><p>Four Left Turning Tendencies</p><p><strong>1:</strong> Torque Effect - Newtons Third Law = Every action has an equal and opposite reaction.</p><p>The action of the propeller spinning clockwise makes the aircraft roll in the opposite direction to the left. Worse at high power settings but engine is offset to counteract this.</p><p><strong>2:</strong> <span class=\"popup-word\">*Gyroscopic Precession</span> - When you pitch up force is applied to the bottom of the spinning propeller,</p><p>this then actually gets applied 90 degrees into the turn later which actually pushes the nose to the right,</p><p>It is only a left turning tendency in descents and actually counteracts some of the others, in tail draggers you pitch down to land so it add to them.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nFour Left Turning Tendencies\n1: Torque Effect - Newtons Third Law = Every action has an equal and opposite reaction.\nThe action of the propeller spinning clockwise makes the aircraft roll in the opposite direction to the left. Worse at high power settings but engine is offset to counteract this.\n2: P Factor - In High angles of attack the downward moving blade is facing into the wind more so it has a higher angle of attack also.\nThis means it's generating more thrust on the right downward moving side generating more thrust and making a yaw to the left.\n3: Spiraling Slipstream - At High power settings and low airspeeds the wind from the propeller spirals around the plane.\nThis eventually hits the vertical stabilizer on the left side pushing it creating a yaw to the left.\n4: *Gyroscopic Precession - When you pitch up force is applied to the bottom of the spinning propeller,\nthis then actually gets applied 90 degrees into the turn later which actually pushes the nose to the right,\nIt is only a left turning tendency in descents and actually counteracts some of the others, in tail draggers you pitch down to land so it add to them.\n\nHow:\n\nWhy:\n",
           "title": "Left Turning Tendencies",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>The <span class=\"popup-word\">airflow</span> directly opposite the aircrafts flight path.</p><p>Your angle of attack changes when you say increase your pitch but at a slower airspeed so your flight path</p><p>is still traveling the same direction but at a higher pitched up angle or angle of attack.</p><p><br></p><p>Angle of Attack - Is the Angle between the chord line and relative wind.</p>",
-          "rawText": "The airflow directly opposite the aircrafts flight path.\nYour angle of attack changes when you say increase your pitch but at a slower airspeed so your flight path\nis still traveling the same direction but at a higher pitched up angle or angle of attack.\n\nAngle of Attack - Is the Angle between the chord line and relative wind.\n",
+          "rawHtml": "<h3>What</h3><p>The <span class=\"popup-word\">airflow</span> directly opposite the aircrafts flight path.</p><p>Your angle of attack changes when you say increase your pitch but at a slower airspeed so your flight path</p><p>is still traveling the same direction but at a higher pitched up angle or angle of attack.</p><p><br></p><p>Angle of Attack - Is the Angle between the chord line and relative wind.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nThe airflow directly opposite the aircrafts flight path.\nYour angle of attack changes when you say increase your pitch but at a slower airspeed so your flight path\nis still traveling the same direction but at a higher pitched up angle or angle of attack.\n\nAngle of Attack - Is the Angle between the chord line and relative wind.\n\nHow:\n\nWhy:\n",
           "title": "Relative Wind",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Aircraft Stability",
           "type": "fill"
         },
@@ -2080,10 +2080,10 @@
               "occ": 4
             }
           ],
-          "rawText": "Induced Drag\nByproduct of lift - Increases with Angle of Attack\nCause by Wingtip Vortices\nParasite Drags (3)\nIncreases with speed\nForm Drag - Shape of Aircraft\nSkin Friction Drag - Surface of Aircraft\nInterference Drag - Connecting Surfaces\n",
+          "rawText": "What:\nInduced Drag\nByproduct of lift - Increases with Angle of Attack\nCause by Wingtip Vortices\nParasite Drags (3)\nIncreases with speed\nForm Drag - Shape of Aircraft\nSkin Friction Drag - Surface of Aircraft\nInterference Drag - Connecting Surfaces\n\nHow:\n\nWhy:\n",
           "title": "Types of Drag",
           "type": "fill",
-          "rawHtml": "<p><strong><u>Induced Drag</u></strong></p><p>Byproduct of lift - Increases with Angle of Attack</p><p>Cause by Wingtip Vortices</p><p><strong><u>Parasite Drags (3)</u></strong></p><p>Increases with speed</p><ul><li>Form Drag - Shape of Aircraft</li><li>Skin Friction Drag - Surface of Aircraft</li><li>Interference Drag - Connecting Surfaces</li></ul>"
+          "rawHtml": "<h3>What</h3><p><strong><u>Induced Drag</u></strong></p><p>Byproduct of lift - Increases with Angle of Attack</p><p>Cause by Wingtip Vortices</p><p><strong><u>Parasite Drags (3)</u></strong></p><p>Increases with speed</p><ul><li>Form Drag - Shape of Aircraft</li><li>Skin Friction Drag - Surface of Aircraft</li><li>Interference Drag - Connecting Surfaces</li></ul><h3>How</h3><p></p><h3>Why</h3><p></p>"
         }
       ],
       "color": "#d9eb37"
@@ -2127,8 +2127,8 @@
               "word": "Report"
             }
           ],
-          "rawHtml": "<p><strong>Meteorological Aerodrome Report</strong></p><p>Reports showing current weather conditions around an airport.</p><p>Reports are released hourly 55 minutes after the hour. </p><p>Routine Conditions can be expected within a 5 SM radius of the airport.</p><p>SPECIs are unscheduled METARs released when there is a sudden or drastic change. </p><p>*VV or vertical visibility counts as a ceiling - caused by things like fog.</p>",
-          "rawText": "Meteorological Aerodrome Report\nReports showing current weather conditions around an airport.\nReports are released hourly 55 minutes after the hour. \nRoutine Conditions can be expected within a 5 SM radius of the airport.\nSPECIs are unscheduled METARs released when there is a sudden or drastic change. \n*VV or vertical visibility counts as a ceiling - caused by things like fog.\n",
+          "rawHtml": "<h3>What</h3><p><strong>Meteorological Aerodrome Report</strong></p><p>Reports showing current weather conditions around an airport.</p><p>Reports are released hourly 55 minutes after the hour. </p><p>Routine Conditions can be expected within a 5 SM radius of the airport.</p><p>SPECIs are unscheduled METARs released when there is a sudden or drastic change. </p><p>*VV or vertical visibility counts as a ceiling - caused by things like fog.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nMeteorological Aerodrome Report\nReports showing current weather conditions around an airport.\nReports are released hourly 55 minutes after the hour. \nRoutine Conditions can be expected within a 5 SM radius of the airport.\nSPECIs are unscheduled METARs released when there is a sudden or drastic change. \n*VV or vertical visibility counts as a ceiling - caused by things like fog.\n\nHow:\n\nWhy:\n",
           "title": "METARs",
           "type": "fill"
         },
@@ -2168,8 +2168,8 @@
               "word": "5/8"
             }
           ],
-          "rawHtml": "<p><strong>Terminal Aerodrome Forecast</strong></p><p>Reports of Forecasted Weather around an airport.</p><p>Has a radius of 5 SM from the center of the runway complex. </p><p>Issued 4 times a day every 6 hours and valid for 24 hours.</p><p>Really big airports might have ones valid for 30 hours. </p><p>FG is reported for visibility less than 5/8 SM - BR is reported when it is more then 5/8 SM.</p>",
-          "rawText": "Terminal Aerodrome Forecast\nReports of Forecasted Weather around an airport.\nHas a radius of 5 SM from the center of the runway complex. \nIssued 4 times a day every 6 hours and valid for 24 hours.\nReally big airports might have ones valid for 30 hours. \nFG is reported for visibility less than 5/8 SM - BR is reported when it is more then 5/8 SM.\n",
+          "rawHtml": "<h3>What</h3><p><strong>Terminal Aerodrome Forecast</strong></p><p>Reports of Forecasted Weather around an airport.</p><p>Has a radius of 5 SM from the center of the runway complex. </p><p>Issued 4 times a day every 6 hours and valid for 24 hours.</p><p>Really big airports might have ones valid for 30 hours. </p><p>FG is reported for visibility less than 5/8 SM - BR is reported when it is more then 5/8 SM.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTerminal Aerodrome Forecast\nReports of Forecasted Weather around an airport.\nHas a radius of 5 SM from the center of the runway complex. \nIssued 4 times a day every 6 hours and valid for 24 hours.\nReally big airports might have ones valid for 30 hours. \nFG is reported for visibility less than 5/8 SM - BR is reported when it is more then 5/8 SM.\n\nHow:\n\nWhy:\n",
           "title": "TAFs",
           "type": "fill"
         },
@@ -2228,8 +2228,8 @@
               "word": "low"
             }
           ],
-          "rawHtml": "<p>Pilot Reports depicting real-time weather conditions, Altitudes in MSL.</p><p>Include the location, time, and type of plane. </p><p>Labelled either UA for routine or UUA for Urgent. </p><p>Urgent reports are for things like tornados | severe turbulence | low level wind shear etc.</p><p>Can be submitted to ATC by radio or to a FSS . </p><p>Can be accessed from foreflight on the ground or ATC/FSS in the air.</p>",
-          "rawText": "Pilot Reports depicting real-time weather conditions, Altitudes in MSL.\nInclude the location, time, and type of plane. \nLabelled either UA for routine or UUA for Urgent. \nUrgent reports are for things like tornados | severe turbulence | low level wind shear etc.\nCan be submitted to ATC by radio or to a FSS . \nCan be accessed from foreflight on the ground or ATC/FSS in the air.\n",
+          "rawHtml": "<h3>What</h3><p>Pilot Reports depicting real-time weather conditions, Altitudes in MSL.</p><p>Include the location, time, and type of plane. </p><p>Labelled either UA for routine or UUA for Urgent. </p><p>Urgent reports are for things like tornados | severe turbulence | low level wind shear etc.</p><p>Can be submitted to ATC by radio or to a FSS . </p><p>Can be accessed from foreflight on the ground or ATC/FSS in the air.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPilot Reports depicting real-time weather conditions, Altitudes in MSL.\nInclude the location, time, and type of plane. \nLabelled either UA for routine or UUA for Urgent. \nUrgent reports are for things like tornados | severe turbulence | low level wind shear etc.\nCan be submitted to ATC by radio or to a FSS . \nCan be accessed from foreflight on the ground or ATC/FSS in the air.\n\nHow:\n\nWhy:\n",
           "title": "PIREPs",
           "type": "fill"
         },
@@ -2402,8 +2402,8 @@
               "y": 31
             }
           ],
-          "rawHtml": "<p>Can be indicated by ice pellets or freezing rain.</p>",
-          "rawText": "Can be indicated by ice pellets or freezing rain.\n",
+          "rawHtml": "<h3>What</h3><p>Can be indicated by ice pellets or freezing rain.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan be indicated by ice pellets or freezing rain.\n\nHow:\n\nWhy:\n",
           "title": "Surface Analysis Chart",
           "type": "label"
         },
@@ -2495,8 +2495,8 @@
               "word": "Tropical"
             }
           ],
-          "rawHtml": "<p>All weather is the result of a heat exchange</p><p>Pressure differences create wind flowing from high to low</p><p>Temperature decreases -2 C per 1000 ft with a normal lapse rate and stops at the tropopause</p><p>Lower levels of atmosphere where weather occurs are Troposphere | Tropopause | Stratosphere</p><p>Air is composed of 78 % Nitrogen and 21 % Oxygen and 1 % other</p><p><br></p><p><strong style=\"color: rgb(0, 71, 178);\">Air Masses</strong></p><p>Continental - Desert</p><p>Maritime - Ocean</p><p>Polar - Cold</p><p>Tropical - Forrest</p>",
-          "rawText": "All weather is the result of a heat exchange\nPressure differences create wind flowing from high to low\nTemperature decreases -2 C per 1000 ft with a normal lapse rate and stops at the tropopause\nLower levels of atmosphere where weather occurs are Troposphere | Tropopause | Stratosphere\nAir is composed of 78 % Nitrogen and 21 % Oxygen and 1 % other\n\nAir Masses\nContinental - Desert\nMaritime - Ocean\nPolar - Cold\nTropical - Forrest\n",
+          "rawHtml": "<h3>What</h3><p>All weather is the result of a heat exchange</p><p>Pressure differences create wind flowing from high to low</p><p>Temperature decreases -2 C per 1000 ft with a normal lapse rate and stops at the tropopause</p><p>Lower levels of atmosphere where weather occurs are Troposphere | Tropopause | Stratosphere</p><p>Air is composed of 78 % Nitrogen and 21 % Oxygen and 1 % other</p><p><br></p><p><strong style=\"color: rgb(0, 71, 178);\">Air Masses</strong></p><p>Continental - Desert</p><p>Maritime - Ocean</p><p>Polar - Cold</p><p>Tropical - Forrest</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAll weather is the result of a heat exchange\nPressure differences create wind flowing from high to low\nTemperature decreases -2 C per 1000 ft with a normal lapse rate and stops at the tropopause\nLower levels of atmosphere where weather occurs are Troposphere | Tropopause | Stratosphere\nAir is composed of 78 % Nitrogen and 21 % Oxygen and 1 % other\n\nAir Masses\nContinental - Desert\nMaritime - Ocean\nPolar - Cold\nTropical - Forrest\n\nHow:\n\nWhy:\n",
           "title": "General Weather",
           "type": "fill"
         },
@@ -2581,8 +2581,8 @@
               "y": 25
             }
           ],
-          "rawHtml": "<p>Issued 4 times a day</p>",
-          "rawText": "Issued 4 times a day\n",
+          "rawHtml": "<h3>What</h3><p>Issued 4 times a day</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nIssued 4 times a day\n\nHow:\n\nWhy:\n",
           "title": "Winds and Temperature Aloft",
           "type": "label"
         },
@@ -2661,8 +2661,8 @@
               "occ": 2
             }
           ],
-          "rawHtml": "<p><strong>Airmen's Meteorological Information</strong></p><p>AIRMETs are forecast weather advisories depicting where moderate hazards may occur.</p><p>Issued every 6 hours and valid for 6 hours</p><p>Three Types:</p><p>Tango - Moderate Turbulence | Low Level Wind Shear | Sustained Surface Winds of 30 Knots or more.</p><p>Sierra - Ceilings Less than 1000 ft and/or visibility less than 3 SM affecting over 50 % of the area.</p><p>Zulu - Moderate Icing | Provides Freezing Level Heights</p>",
-          "rawText": "Airmen's Meteorological Information\nAIRMETs are forecast weather advisories depicting where moderate hazards may occur.\nIssued every 6 hours and valid for 6 hours\nThree Types:\nTango - Moderate Turbulence | Low Level Wind Shear | Sustained Surface Winds of 30 Knots or more.\nSierra - Ceilings Less than 1000 ft and/or visibility less than 3 SM affecting over 50 % of the area.\nZulu - Moderate Icing | Provides Freezing Level Heights\n",
+          "rawHtml": "<h3>What</h3><p><strong>Airmen's Meteorological Information</strong></p><p>AIRMETs are forecast weather advisories depicting where moderate hazards may occur.</p><p>Issued every 6 hours and valid for 6 hours</p><p>Three Types:</p><p>Tango - Moderate Turbulence | Low Level Wind Shear | Sustained Surface Winds of 30 Knots or more.</p><p>Sierra - Ceilings Less than 1000 ft and/or visibility less than 3 SM affecting over 50 % of the area.</p><p>Zulu - Moderate Icing | Provides Freezing Level Heights</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAirmen's Meteorological Information\nAIRMETs are forecast weather advisories depicting where moderate hazards may occur.\nIssued every 6 hours and valid for 6 hours\nThree Types:\nTango - Moderate Turbulence | Low Level Wind Shear | Sustained Surface Winds of 30 Knots or more.\nSierra - Ceilings Less than 1000 ft and/or visibility less than 3 SM affecting over 50 % of the area.\nZulu - Moderate Icing | Provides Freezing Level Heights\n\nHow:\n\nWhy:\n",
           "title": "AIRMETs",
           "type": "fill"
         },
@@ -2718,8 +2718,8 @@
               "word": "Ash"
             }
           ],
-          "rawHtml": "<p><strong>Significant Meteorological Information</strong></p><p>SIGMETs are forecast weather advisories depicting significant hazards</p><p>These are Unscheduled generally valid up to 4 hours for areas of at least 3000 square miles</p><p>Include: Severe Icing | Severe Turbulence | Mountain Waves | Dust / Sandstorms with &lt; 3 SM Visibility | Volcanic Ash</p>",
-          "rawText": "Significant Meteorological Information\nSIGMETs are forecast weather advisories depicting significant hazards\nThese are Unscheduled generally valid up to 4 hours for areas of at least 3000 square miles\nInclude: Severe Icing | Severe Turbulence | Mountain Waves | Dust / Sandstorms with < 3 SM Visibility | Volcanic Ash\n",
+          "rawHtml": "<h3>What</h3><p><strong>Significant Meteorological Information</strong></p><p>SIGMETs are forecast weather advisories depicting significant hazards</p><p>These are Unscheduled generally valid up to 4 hours for areas of at least 3000 square miles</p><p>Include: Severe Icing | Severe Turbulence | Mountain Waves | Dust / Sandstorms with &lt; 3 SM Visibility | Volcanic Ash</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nSignificant Meteorological Information\nSIGMETs are forecast weather advisories depicting significant hazards\nThese are Unscheduled generally valid up to 4 hours for areas of at least 3000 square miles\nInclude: Severe Icing | Severe Turbulence | Mountain Waves | Dust / Sandstorms with < 3 SM Visibility | Volcanic Ash\n\nHow:\n\nWhy:\n",
           "title": "SIGMETs",
           "type": "fill"
         },
@@ -2771,8 +2771,8 @@
               "word": "3000"
             }
           ],
-          "rawHtml": "<p>Issued Hourly 55 minutes past the hour | Valid for 2 Hours</p><p>Issued for: Embedded Thunderstorms | Surface winds &gt; 50 Knots | Hail 3/4 Inch Diameter | Tornados | Heavy Rain Thunderstorms covering 40% of the 3000 Square Mile Area.</p>",
-          "rawText": "Issued Hourly 55 minutes past the hour | Valid for 2 Hours\nIssued for: Embedded Thunderstorms | Surface winds > 50 Knots | Hail 3/4 Inch Diameter | Tornados | Heavy Rain Thunderstorms covering 40% of the 3000 Square Mile Area.",
+          "rawHtml": "<h3>What</h3><p>Issued Hourly 55 minutes past the hour | Valid for 2 Hours</p><p>Issued for: Embedded Thunderstorms | Surface winds &gt; 50 Knots | Hail 3/4 Inch Diameter | Tornados | Heavy Rain Thunderstorms covering 40% of the 3000 Square Mile Area.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nIssued Hourly 55 minutes past the hour | Valid for 2 Hours\nIssued for: Embedded Thunderstorms | Surface winds > 50 Knots | Hail 3/4 Inch Diameter | Tornados | Heavy Rain Thunderstorms covering 40% of the 3000 Square Mile Area.\n\nHow:\n\nWhy:\n",
           "title": "Convective SIGMETs",
           "type": "fill"
         },
@@ -2824,8 +2824,8 @@
               "word": "night."
             }
           ],
-          "rawHtml": "<p>LIFR Conditions: Ceilings less than 500 ft and/or visibility  less than 1 SM. </p><p>IFR Conditions: Ceilings less than 1000 ft and/or visibility less than 3 SM.</p><p>Marginal VFR: Ceiling more than 1000 ft and visibility more than 3 SM</p><p>VFR Conditions: Ceiling more than 3000 ft and visibility more than 5 SM</p><p>Special VFR: 1 SM visibility and CoC - Need to be IFR legal to do this at night.</p>",
-          "rawText": "LIFR Conditions: Ceilings less than 500 ft and/or visibility  less than 1 SM. \nIFR Conditions: Ceilings less than 1000 ft and/or visibility less than 3 SM.\nMarginal VFR: Ceiling more than 1000 ft and visibility more than 3 SM\nVFR Conditions: Ceiling more than 3000 ft and visibility more than 5 SM\nSpecial VFR: 1 SM visibility and CoC - Need to be IFR legal to do this at night.\n",
+          "rawHtml": "<h3>What</h3><p>LIFR Conditions: Ceilings less than 500 ft and/or visibility  less than 1 SM. </p><p>IFR Conditions: Ceilings less than 1000 ft and/or visibility less than 3 SM.</p><p>Marginal VFR: Ceiling more than 1000 ft and visibility more than 3 SM</p><p>VFR Conditions: Ceiling more than 3000 ft and visibility more than 5 SM</p><p>Special VFR: 1 SM visibility and CoC - Need to be IFR legal to do this at night.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nLIFR Conditions: Ceilings less than 500 ft and/or visibility  less than 1 SM. \nIFR Conditions: Ceilings less than 1000 ft and/or visibility less than 3 SM.\nMarginal VFR: Ceiling more than 1000 ft and visibility more than 3 SM\nVFR Conditions: Ceiling more than 3000 ft and visibility more than 5 SM\nSpecial VFR: 1 SM visibility and CoC - Need to be IFR legal to do this at night.\n\nHow:\n\nWhy:\n",
           "title": "IFR / VFR Conditions",
           "type": "fill"
         },
@@ -2857,8 +2857,8 @@
               "word": "36,000"
             }
           ],
-          "rawHtml": "<p>The atmosphere is made up of 78 % Nitrogen and 21 % Oxygen</p><p>The three lowest layers and ones notable for aviation are</p><p>Troposphere - Where almost all weather takes place, Up to around 36,000 ft </p><p>Standard lapse rate of -2 C per 1000 ft, and pressure decreases by 1 inch Hg.</p><p>Tropopause - Boundary Layer between tropo and strato spheres.</p><p>Lapse rate goes down to zero</p><p>Stratosphere - Commercial aircraft often cruise in the lower stratosphere to avoid weather.</p><p>Lapse rate reverses slightly</p>",
-          "rawText": "The atmosphere is made up of 78 % Nitrogen and 21 % Oxygen\nThe three lowest layers and ones notable for aviation are\nTroposphere - Where almost all weather takes place, Up to around 36,000 ft \nStandard lapse rate of -2 C per 1000 ft, and pressure decreases by 1 inch Hg.\nTropopause - Boundary Layer between tropo and strato spheres.\nLapse rate goes down to zero\nStratosphere - Commercial aircraft often cruise in the lower stratosphere to avoid weather.\nLapse rate reverses slightly\n",
+          "rawHtml": "<h3>What</h3><p>The atmosphere is made up of 78 % Nitrogen and 21 % Oxygen</p><p>The three lowest layers and ones notable for aviation are</p><p>Troposphere - Where almost all weather takes place, Up to around 36,000 ft </p><p>Standard lapse rate of -2 C per 1000 ft, and pressure decreases by 1 inch Hg.</p><p>Tropopause - Boundary Layer between tropo and strato spheres.</p><p>Lapse rate goes down to zero</p><p>Stratosphere - Commercial aircraft often cruise in the lower stratosphere to avoid weather.</p><p>Lapse rate reverses slightly</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nThe atmosphere is made up of 78 % Nitrogen and 21 % Oxygen\nThe three lowest layers and ones notable for aviation are\nTroposphere - Where almost all weather takes place, Up to around 36,000 ft \nStandard lapse rate of -2 C per 1000 ft, and pressure decreases by 1 inch Hg.\nTropopause - Boundary Layer between tropo and strato spheres.\nLapse rate goes down to zero\nStratosphere - Commercial aircraft often cruise in the lower stratosphere to avoid weather.\nLapse rate reverses slightly\n\nHow:\n\nWhy:\n",
           "title": "Atmospheric Composition",
           "type": "fill"
         },
@@ -2886,32 +2886,32 @@
               "word": "Outlook"
             }
           ],
-          "rawHtml": "<p>Standard Briefing - A full briefing, get one if you are within 6 hours of your ETD.</p><p>Abbreviated Briefing - Used to update a previous briefing.</p><p>Outlook Briefing - Used if your ETD is more than 6 hours away.</p>",
-          "rawText": "Standard Briefing - A full briefing, get one if you are within 6 hours of your ETD.\nAbbreviated Briefing - Used to update a previous briefing.\nOutlook Briefing - Used if your ETD is more than 6 hours away.\n",
+          "rawHtml": "<h3>What</h3><p>Standard Briefing - A full briefing, get one if you are within 6 hours of your ETD.</p><p>Abbreviated Briefing - Used to update a previous briefing.</p><p>Outlook Briefing - Used if your ETD is more than 6 hours away.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nStandard Briefing - A full briefing, get one if you are within 6 hours of your ETD.\nAbbreviated Briefing - Used to update a previous briefing.\nOutlook Briefing - Used if your ETD is more than 6 hours away.\n\nHow:\n\nWhy:\n",
           "title": "FSS Weather Briefings",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Thunderstorms, other convective activity, excessive winds, windshear, excessive turbulence, low clouds / visibility, icing, heavy rain.</p>",
-          "rawText": "",
+          "rawHtml": "<h3>What</h3><p>Thunderstorms, other convective activity, excessive winds, windshear, excessive turbulence, low clouds / visibility, icing, heavy rain.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Hazardous Weather",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p><strong>AIM 7-1-3</strong></p><p>FAA / National Weather Services Sources</p>",
-          "rawText": "",
+          "rawHtml": "<h3>What</h3><p><strong>AIM 7-1-3</strong></p><p>FAA / National Weather Services Sources</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Approved Sources of Weather",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Observations generated every 4 - 11 minutes valid from the end of the last scan.</p><p>Generated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.</p><p>Doppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.</p><p>A radar echo is just its appearance / color on a radar display.</p><p>Shows precipitation not cloud coverage</p><p>Beams can miss certain areas or be obstructed</p>",
-          "rawText": "",
+          "rawHtml": "<h3>What</h3><p>Observations generated every 4 - 11 minutes valid from the end of the last scan.</p><p>Generated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.</p><p>Doppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.</p><p>A radar echo is just its appearance / color on a radar display.</p><p>Shows precipitation not cloud coverage</p><p>Beams can miss certain areas or be obstructed</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Radar Images",
           "type": "fill"
         },
@@ -2940,8 +2940,8 @@
               "y": 6
             }
           ],
-          "rawHtml": "<p>Observations generated every 4 - 11 minutes valid from the end of the last scan.</p><p>Generated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.</p><p>Doppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.</p><p>A radar echo is just its appearance / color on a radar display.</p><p>Shows precipitation not cloud coverage</p><p>Beams can miss certain areas or be obstructed</p>",
-          "rawText": "Observations generated every 4 - 11 minutes valid from the end of the last scan.\nGenerated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.\nDoppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.\nA radar echo is just its appearance / color on a radar display.\nShows precipitation not cloud coverage\nBeams can miss certain areas or be obstructed\n",
+          "rawHtml": "<h3>What</h3><p>Observations generated every 4 - 11 minutes valid from the end of the last scan.</p><p>Generated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.</p><p>Doppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.</p><p>A radar echo is just its appearance / color on a radar display.</p><p>Shows precipitation not cloud coverage</p><p>Beams can miss certain areas or be obstructed</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nObservations generated every 4 - 11 minutes valid from the end of the last scan.\nGenerated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.\nDoppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.\nA radar echo is just its appearance / color on a radar display.\nShows precipitation not cloud coverage\nBeams can miss certain areas or be obstructed\n\nHow:\n\nWhy:\n",
           "title": "Low Level Significant Weather Prognostic Chart",
           "type": "label"
         },
@@ -2968,8 +2968,8 @@
               "y": 3
             }
           ],
-          "rawHtml": "<p>Observations generated every 4 - 11 minutes valid from the end of the last scan.</p><p>Generated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.</p><p>Doppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.</p><p>A radar echo is just its appearance / color on a radar display.</p><p>Shows precipitation not cloud coverage</p><p>Beams can miss certain areas or be obstructed</p>",
-          "rawText": "Observations generated every 4 - 11 minutes valid from the end of the last scan.\nGenerated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.\nDoppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.\nA radar echo is just its appearance / color on a radar display.\nShows precipitation not cloud coverage\nBeams can miss certain areas or be obstructed\n",
+          "rawHtml": "<h3>What</h3><p>Observations generated every 4 - 11 minutes valid from the end of the last scan.</p><p>Generated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.</p><p>Doppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.</p><p>A radar echo is just its appearance / color on a radar display.</p><p>Shows precipitation not cloud coverage</p><p>Beams can miss certain areas or be obstructed</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nObservations generated every 4 - 11 minutes valid from the end of the last scan.\nGenerated in the US by Doppler Radars which make up the NEXRAD system used by NWS and FAA.\nDoppler Radar - Sends out signals that reflect or echo off of precipitation, it measures the reflective power of this and the higher the more intense precipitation.\nA radar echo is just its appearance / color on a radar display.\nShows precipitation not cloud coverage\nBeams can miss certain areas or be obstructed\n\nHow:\n\nWhy:\n",
           "title": "Convective Outlook Chart",
           "type": "label"
         },
@@ -3001,8 +3001,8 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p><strong>Center Weather Advisory</strong></p><p>Issued for hazardous conditions not covered under AIRMETs or SIGMETs. </p><p>Used for 2 Hour periods.</p><p>Issued by ARTCC and Broadcast by ATC to warn pilots also available from FSS or datalink or online. </p>",
-          "rawText": "Center Weather Advisory\nIssued for hazardous conditions not covered under AIRMETs or SIGMETs. \nUsed for 2 Hour periods.\nIssued by ARTCC and Broadcast by ATC to warn pilots also available from FSS or datalink or online. \n",
+          "rawHtml": "<h3>What</h3><p><strong>Center Weather Advisory</strong></p><p>Issued for hazardous conditions not covered under AIRMETs or SIGMETs. </p><p>Used for 2 Hour periods.</p><p>Issued by ARTCC and Broadcast by ATC to warn pilots also available from FSS or datalink or online. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCenter Weather Advisory\nIssued for hazardous conditions not covered under AIRMETs or SIGMETs. \nUsed for 2 Hour periods.\nIssued by ARTCC and Broadcast by ATC to warn pilots also available from FSS or datalink or online. \n\nHow:\n\nWhy:\n",
           "title": "Center Weather Advisory (CWA)",
           "type": "fill"
         },
@@ -3038,8 +3038,8 @@
               "word": "Advisories."
             }
           ],
-          "rawHtml": "<p>Include AIRMETs, SIGMETs, Convective SIGMETs, and Center Weather Advisories. </p><p>Issued by the Aviation Weather Center (AWC) and periodically announced by ATC to pilots.</p>",
-          "rawText": "Include AIRMETs, SIGMETs, Convective SIGMETs, and Center Weather Advisories. \nIssued by the Aviation Weather Center (AWC) and periodically announced by ATC to pilots.\n",
+          "rawHtml": "<h3>What</h3><p>Include AIRMETs, SIGMETs, Convective SIGMETs, and Center Weather Advisories. </p><p>Issued by the Aviation Weather Center (AWC) and periodically announced by ATC to pilots.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nInclude AIRMETs, SIGMETs, Convective SIGMETs, and Center Weather Advisories. \nIssued by the Aviation Weather Center (AWC) and periodically announced by ATC to pilots.\n\nHow:\n\nWhy:\n",
           "title": "Inflight Aviation Weather Advisories",
           "type": "fill"
         },
@@ -3075,8 +3075,8 @@
               "word": "unstable"
             }
           ],
-          "rawHtml": "<p>Atmospheric Stability is the ability to resist vertical motion.</p><p>In a stable atmosphere air pushed up will quickly stop rising, and in an unstable one it will keep rising.</p><p>The Stability is determined by the Temperature and Moisture of the atmosphere.</p><p>Cool and dry air is stable - Warm and Wet air is unstable</p><p>Warm air rises and water vapor is lighter than air so less dense and rises more.</p>",
-          "rawText": "Atmospheric Stability is the ability to resist vertical motion.\nIn a stable atmosphere air pushed up will quickly stop rising, and in an unstable one it will keep rising.\nThe Stability is determined by the Temperature and Moisture of the atmosphere.\nCool and dry air is stable - Warm and Wet air is unstable\nWarm air rises and water vapor is lighter than air so less dense and rises more.\n",
+          "rawHtml": "<h3>What</h3><p>Atmospheric Stability is the ability to resist vertical motion.</p><p>In a stable atmosphere air pushed up will quickly stop rising, and in an unstable one it will keep rising.</p><p>The Stability is determined by the Temperature and Moisture of the atmosphere.</p><p>Cool and dry air is stable - Warm and Wet air is unstable</p><p>Warm air rises and water vapor is lighter than air so less dense and rises more.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAtmospheric Stability is the ability to resist vertical motion.\nIn a stable atmosphere air pushed up will quickly stop rising, and in an unstable one it will keep rising.\nThe Stability is determined by the Temperature and Moisture of the atmosphere.\nCool and dry air is stable - Warm and Wet air is unstable\nWarm air rises and water vapor is lighter than air so less dense and rises more.\n\nHow:\n\nWhy:\n",
           "title": "Stable/Unstable Atmospheres",
           "type": "fill"
         },
@@ -3108,8 +3108,8 @@
               "word": "vertical"
             }
           ],
-          "rawHtml": "<p>Wind is caused by uneven heating of the Earth's surface which makes pressure and density differences.</p><p>Air moves from low to high pressure and is deflected to the right by the Coriolis force in the Northern Hemisphere.</p><p>Wind is Horizontal movement of air, Convective Currents are vertical movements.</p><p>On short final pavement can cause updrafts and water or vegetation like trees can cause downdrafts.</p><p><br></p>",
-          "rawText": "Wind is caused by uneven heating of the Earth's surface which makes pressure and density differences.\nAir moves from low to high pressure and is deflected to the right by the Coriolis force in the Northern Hemisphere.\nWind is Horizontal movement of air, Convective Currents are vertical movements.\nOn short final pavement can cause updrafts and water or vegetation like trees can cause downdrafts.\n\n",
+          "rawHtml": "<h3>What</h3><p>Wind is caused by uneven heating of the Earth's surface which makes pressure and density differences.</p><p>Air moves from low to high pressure and is deflected to the right by the Coriolis force in the Northern Hemisphere.</p><p>Wind is Horizontal movement of air, Convective Currents are vertical movements.</p><p>On short final pavement can cause updrafts and water or vegetation like trees can cause downdrafts.</p><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWind is caused by uneven heating of the Earth's surface which makes pressure and density differences.\nAir moves from low to high pressure and is deflected to the right by the Coriolis force in the Northern Hemisphere.\nWind is Horizontal movement of air, Convective Currents are vertical movements.\nOn short final pavement can cause updrafts and water or vegetation like trees can cause downdrafts.\n\nHow:\n\nWhy:\n",
           "title": "Wind",
           "type": "fill"
         },
@@ -3145,8 +3145,8 @@
               "word": "Alto"
             }
           ],
-          "rawHtml": "<p>A cloud ceiling is defined as the lowest layer that obscures more than half the sky so broken or overcast layers.</p><p>Clouds are caused by condensation when water vapor in rising air current cools to its dew point and condenses into visible moisture.</p><p>Most dangerous type of clouds are cumulonimbus clouds, lenticular clouds over mountains also indicate excessive turbulence (Lens Shaped).</p><p>Stratus - Lowest</p><p>Alto - Medium</p><p>Cirrus - High</p>",
-          "rawText": "A cloud ceiling is defined as the lowest layer that obscures more than half the sky so broken or overcast layers.\nClouds are caused by condensation when water vapor in rising air current cools to its dew point and condenses into visible moisture.\nMost dangerous type of clouds are cumulonimbus clouds, lenticular clouds over mountains also indicate excessive turbulence (Lens Shaped).\nStratus - Lowest\nAlto - Medium\nCirrus - High\n",
+          "rawHtml": "<h3>What</h3><p>A cloud ceiling is defined as the lowest layer that obscures more than half the sky so broken or overcast layers.</p><p>Clouds are caused by condensation when water vapor in rising air current cools to its dew point and condenses into visible moisture.</p><p>Most dangerous type of clouds are cumulonimbus clouds, lenticular clouds over mountains also indicate excessive turbulence (Lens Shaped).</p><p>Stratus - Lowest</p><p>Alto - Medium</p><p>Cirrus - High</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nA cloud ceiling is defined as the lowest layer that obscures more than half the sky so broken or overcast layers.\nClouds are caused by condensation when water vapor in rising air current cools to its dew point and condenses into visible moisture.\nMost dangerous type of clouds are cumulonimbus clouds, lenticular clouds over mountains also indicate excessive turbulence (Lens Shaped).\nStratus - Lowest\nAlto - Medium\nCirrus - High\n\nHow:\n\nWhy:\n",
           "title": "Clouds",
           "type": "fill"
         },
@@ -3182,8 +3182,8 @@
               "word": "land"
             }
           ],
-          "rawHtml": "<p>Water holds its temperature better than land so it takes longer to heat up and cool down.</p><p>During the day the land air warms quicker and becomes less dense so it rises</p><p>The cooler air sill over the water then flows in to replace it causing a Sea Breeze.</p><p>At Night land cools quicker so the warmer air over the water rises and is replaced by the land air causing a Land Breeze.</p>",
-          "rawText": "Water holds its temperature better than land so it takes longer to heat up and cool down.\nDuring the day the land air warms quicker and becomes less dense so it rises\nThe cooler air sill over the water then flows in to replace it causing a Sea Breeze.\nAt Night land cools quicker so the warmer air over the water rises and is replaced by the land air causing a Land Breeze.\n",
+          "rawHtml": "<h3>What</h3><p>Water holds its temperature better than land so it takes longer to heat up and cool down.</p><p>During the day the land air warms quicker and becomes less dense so it rises</p><p>The cooler air sill over the water then flows in to replace it causing a Sea Breeze.</p><p>At Night land cools quicker so the warmer air over the water rises and is replaced by the land air causing a Land Breeze.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWater holds its temperature better than land so it takes longer to heat up and cool down.\nDuring the day the land air warms quicker and becomes less dense so it rises\nThe cooler air sill over the water then flows in to replace it causing a Sea Breeze.\nAt Night land cools quicker so the warmer air over the water rises and is replaced by the land air causing a Land Breeze.\n\nHow:\n\nWhy:\n",
           "title": "Sea/Land Breezes",
           "type": "fill"
         },
@@ -3203,8 +3203,8 @@
               "word": "lenticular"
             }
           ],
-          "rawHtml": "<p>Turbulent waves that form when stable air flows over a mountain.</p><p>They form above and downwind of the mountain and their presence can be known by lenticular clouds.</p><p>So in windy conditions the downwind side has generally worse weather as mountain waves can extend miles.</p>",
-          "rawText": "Turbulent waves that form when stable air flows over a mountain.\nThey form above and downwind of the mountain and their presence can be known by lenticular clouds.\nSo in windy conditions the downwind side has generally worse weather as mountain waves can extend miles.\n",
+          "rawHtml": "<h3>What</h3><p>Turbulent waves that form when stable air flows over a mountain.</p><p>They form above and downwind of the mountain and their presence can be known by lenticular clouds.</p><p>So in windy conditions the downwind side has generally worse weather as mountain waves can extend miles.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTurbulent waves that form when stable air flows over a mountain.\nThey form above and downwind of the mountain and their presence can be known by lenticular clouds.\nSo in windy conditions the downwind side has generally worse weather as mountain waves can extend miles.\n\nHow:\n\nWhy:\n",
           "title": "Mountain Waves",
           "type": "fill"
         },
@@ -3244,8 +3244,8 @@
               "word": "Relative"
             }
           ],
-          "rawHtml": "<p>Hot air is less dense and can hold more moisture. </p><p>Dew Point is the temperature the air must be cooled to become fully saturated.</p><p>Once they are equal if any more moisture is added then the water vapor will turn into visible moisture.</p><p>Relative Humidity - The amount of moisture in the air compared to the total amount it could hold. </p><p>So a relative humidity of 65% means it's holding 65% of what it is capable of holding.</p>",
-          "rawText": "Hot air is less dense and can hold more moisture. \nDew Point is the temperature the air must be cooled to become fully saturated.\nOnce they are equal if any more moisture is added then the water vapor will turn into visible moisture.\nRelative Humidity - The amount of moisture in the air compared to the total amount it could hold. \nSo a relative humidity of 65% means it's holding 65% of what it is capable of holding.\n",
+          "rawHtml": "<h3>What</h3><p>Hot air is less dense and can hold more moisture. </p><p>Dew Point is the temperature the air must be cooled to become fully saturated.</p><p>Once they are equal if any more moisture is added then the water vapor will turn into visible moisture.</p><p>Relative Humidity - The amount of moisture in the air compared to the total amount it could hold. </p><p>So a relative humidity of 65% means it's holding 65% of what it is capable of holding.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nHot air is less dense and can hold more moisture. \nDew Point is the temperature the air must be cooled to become fully saturated.\nOnce they are equal if any more moisture is added then the water vapor will turn into visible moisture.\nRelative Humidity - The amount of moisture in the air compared to the total amount it could hold. \nSo a relative humidity of 65% means it's holding 65% of what it is capable of holding.\n\nHow:\n\nWhy:\n",
           "title": "Moisture/Temperature",
           "type": "fill"
         },
@@ -3269,16 +3269,16 @@
               "word": "Deposition"
             }
           ],
-          "rawHtml": "<p>Evaporation - Liquid to Gas (Lake Drying up)</p><p>Sublimation - Solid to Gas (Dry Ice)</p><p>Condensation - Gas to Liquid (Clouds)</p><p>Deposition - Gas to solid (Frost)</p>",
-          "rawText": "Evaporation - Liquid to Gas (Lake Drying up)\nSublimation - Solid to Gas (Dry Ice)\nCondensation - Gas to Liquid (Clouds)\nDeposition - Gas to solid (Frost)\n",
+          "rawHtml": "<h3>What</h3><p>Evaporation - Liquid to Gas (Lake Drying up)</p><p>Sublimation - Solid to Gas (Dry Ice)</p><p>Condensation - Gas to Liquid (Clouds)</p><p>Deposition - Gas to solid (Frost)</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nEvaporation - Liquid to Gas (Lake Drying up)\nSublimation - Solid to Gas (Dry Ice)\nCondensation - Gas to Liquid (Clouds)\nDeposition - Gas to solid (Frost)\n\nHow:\n\nWhy:\n",
           "title": "Water State Transitions",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Can be indicated by ice pellets or freezing rain.</p>",
-          "rawText": "Can be indicated by ice pellets or freezing rain.\n",
+          "rawHtml": "<h3>What</h3><p>Can be indicated by ice pellets or freezing rain.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCan be indicated by ice pellets or freezing rain.\n\nHow:\n\nWhy:\n",
           "title": "Temperature Inversions",
           "type": "fill"
         },
@@ -3330,8 +3330,8 @@
               "word": "warm"
             }
           ],
-          "rawHtml": "<p><strong style=\"color: rgb(0, 102, 204);\">Three Types</strong> - </p><ul><li>Convective: Uneven Heating of Earths surface, sunny afternoons with little wind cause bubbles of warm air to rise.</li><li>Mechanical: Caused by obstructions like mountains (Mountain Waves) or buildings. </li><li>Wind Shear: Turbulence generated between two wind currents - Temperature Inversions and Clear air turbulence around the jet stream.</li></ul><p><strong style=\"color: rgb(0, 102, 204);\">Four Levels of Intensity</strong> - </p><ul><li>Light - Slight changes in altitude or attitude, slight strain felt.</li><li>Moderate - Changes in altitude or attitude, positive control maintained, definite strain felt.</li><li>Severe - Large changes in altitude or attitude, may lose control momentarily, forceful strains felt.</li><li>Extreme - Aircraft violently tossed around, impossible to control, may lead to structural damage.</li></ul><p>*Clear Air Turbulence (CAT) can be best located from PIREPs.</p>",
-          "rawText": "Three Types - \nConvective: Uneven Heating of Earths surface, sunny afternoons with little wind cause bubbles of warm air to rise.\nMechanical: Caused by obstructions like mountains (Mountain Waves) or buildings. \nWind Shear: Turbulence generated between two wind currents - Temperature Inversions and Clear air turbulence around the jet stream.\nFour Levels of Intensity - \nLight - Slight changes in altitude or attitude, slight strain felt.\nModerate - Changes in altitude or attitude, positive control maintained, definite strain felt.\nSevere - Large changes in altitude or attitude, may lose control momentarily, forceful strains felt.\nExtreme - Aircraft violently tossed around, impossible to control, may lead to structural damage.\n*Clear Air Turbulence (CAT) can be best located from PIREPs.\n",
+          "rawHtml": "<h3>What</h3><p><strong style=\"color: rgb(0, 102, 204);\">Three Types</strong> - </p><ul><li>Convective: Uneven Heating of Earths surface, sunny afternoons with little wind cause bubbles of warm air to rise.</li><li>Mechanical: Caused by obstructions like mountains (Mountain Waves) or buildings. </li><li>Wind Shear: Turbulence generated between two wind currents - Temperature Inversions and Clear air turbulence around the jet stream.</li></ul><p><strong style=\"color: rgb(0, 102, 204);\">Four Levels of Intensity</strong> - </p><ul><li>Light - Slight changes in altitude or attitude, slight strain felt.</li><li>Moderate - Changes in altitude or attitude, positive control maintained, definite strain felt.</li><li>Severe - Large changes in altitude or attitude, may lose control momentarily, forceful strains felt.</li><li>Extreme - Aircraft violently tossed around, impossible to control, may lead to structural damage.</li></ul><p>*Clear Air Turbulence (CAT) can be best located from PIREPs.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nThree Types - \nConvective: Uneven Heating of Earths surface, sunny afternoons with little wind cause bubbles of warm air to rise.\nMechanical: Caused by obstructions like mountains (Mountain Waves) or buildings. \nWind Shear: Turbulence generated between two wind currents - Temperature Inversions and Clear air turbulence around the jet stream.\nFour Levels of Intensity - \nLight - Slight changes in altitude or attitude, slight strain felt.\nModerate - Changes in altitude or attitude, positive control maintained, definite strain felt.\nSevere - Large changes in altitude or attitude, may lose control momentarily, forceful strains felt.\nExtreme - Aircraft violently tossed around, impossible to control, may lead to structural damage.\n*Clear Air Turbulence (CAT) can be best located from PIREPs.\n\nHow:\n\nWhy:\n",
           "title": "Turbulence",
           "type": "fill"
         },
@@ -3403,8 +3403,8 @@
               "word": "Line"
             }
           ],
-          "rawHtml": "<p><strong style=\"color: rgb(0, 97, 0);\">Required to Form</strong></p><p>Moisture <strong>|</strong> Unstable Air <strong>|</strong> Lifting Force</p><p><br></p><p><strong style=\"color: rgb(0, 97, 0);\">Stages</strong></p><p>Cumulus - Strong Updrafts</p><p>Mature - Precipitation starts to fall creating downdrafts alongside the updrafts - Peak Intensity.</p><p>Dissipating -  Mostly downdrafts</p><p><br></p><p><strong style=\"color: rgb(0, 97, 0);\">Types of Thunderstorms</strong></p><p>Steady State - Driven by Fronts</p><p>Airmass - Naturally Formed from Air Masses</p><p>Embedded - Obscured by clouds often from occluded fronts</p><p>Squall Line - Long line of thunderstorms</p><p><br></p><p>*Thunderstorms bring turbulence, icing, hail, heavy rain, sometimes tornados.</p><p>*There are single cell, multi cell, and super cell thunderstorms based on their size.</p><p>*End of the mature stage is marked by an anvil cloud top.</p><p>*Don't turn back if you accidentally enter a thunderstorm, maintain attitude while letting others fluctuate, disengage autopilot.</p><p> Use an airspeed a little under maneuvering speed.</p><p>*Remain clear of thunderstorms by 20 miles to avoid strong winds and hail.</p><p>*Can cause microbursts which can have downdrafts up to 6000ft per minute.</p>",
-          "rawText": "Required to Form\nMoisture | Unstable Air | Lifting Force\n\nStages\nCumulus - Strong Updrafts\nMature - Precipitation starts to fall creating downdrafts alongside the updrafts - Peak Intensity.\nDissipating -  Mostly downdrafts\n\nTypes of Thunderstorms\nSteady State - Driven by Fronts\nAirmass - Naturally Formed from Air Masses\nEmbedded - Obscured by clouds often from occluded fronts\nSquall Line - Long line of thunderstorms\n\n*Thunderstorms bring turbulence, icing, hail, heavy rain, sometimes tornados.\n*There are single cell, multi cell, and super cell thunderstorms based on their size.\n*End of the mature stage is marked by an anvil cloud top.\n*Don't turn back if you accidentally enter a thunderstorm, maintain attitude while letting others fluctuate, disengage autopilot.\n Use an airspeed a little under maneuvering speed.\n*Remain clear of thunderstorms by 20 miles to avoid strong winds and hail.\n*Can cause microbursts which can have downdrafts up to 6000ft per minute.\n",
+          "rawHtml": "<h3>What</h3><p><strong style=\"color: rgb(0, 97, 0);\">Required to Form</strong></p><p>Moisture <strong>|</strong> Unstable Air <strong>|</strong> Lifting Force</p><p><br></p><p><strong style=\"color: rgb(0, 97, 0);\">Stages</strong></p><p>Cumulus - Strong Updrafts</p><p>Mature - Precipitation starts to fall creating downdrafts alongside the updrafts - Peak Intensity.</p><p>Dissipating -  Mostly downdrafts</p><p><br></p><p><strong style=\"color: rgb(0, 97, 0);\">Types of Thunderstorms</strong></p><p>Steady State - Driven by Fronts</p><p>Airmass - Naturally Formed from Air Masses</p><p>Embedded - Obscured by clouds often from occluded fronts</p><p>Squall Line - Long line of thunderstorms</p><p><br></p><p>*Thunderstorms bring turbulence, icing, hail, heavy rain, sometimes tornados.</p><p>*There are single cell, multi cell, and super cell thunderstorms based on their size.</p><p>*End of the mature stage is marked by an anvil cloud top.</p><p>*Don't turn back if you accidentally enter a thunderstorm, maintain attitude while letting others fluctuate, disengage autopilot.</p><p> Use an airspeed a little under maneuvering speed.</p><p>*Remain clear of thunderstorms by 20 miles to avoid strong winds and hail.</p><p>*Can cause microbursts which can have downdrafts up to 6000ft per minute.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRequired to Form\nMoisture | Unstable Air | Lifting Force\n\nStages\nCumulus - Strong Updrafts\nMature - Precipitation starts to fall creating downdrafts alongside the updrafts - Peak Intensity.\nDissipating -  Mostly downdrafts\n\nTypes of Thunderstorms\nSteady State - Driven by Fronts\nAirmass - Naturally Formed from Air Masses\nEmbedded - Obscured by clouds often from occluded fronts\nSquall Line - Long line of thunderstorms\n\n*Thunderstorms bring turbulence, icing, hail, heavy rain, sometimes tornados.\n*There are single cell, multi cell, and super cell thunderstorms based on their size.\n*End of the mature stage is marked by an anvil cloud top.\n*Don't turn back if you accidentally enter a thunderstorm, maintain attitude while letting others fluctuate, disengage autopilot.\n Use an airspeed a little under maneuvering speed.\n*Remain clear of thunderstorms by 20 miles to avoid strong winds and hail.\n*Can cause microbursts which can have downdrafts up to 6000ft per minute.\n\nHow:\n\nWhy:\n",
           "title": "Thunderstorms",
           "type": "fill"
         },
@@ -3436,8 +3436,8 @@
               "word": "Ice:"
             }
           ],
-          "rawHtml": "<p>Structural Icing requires Around Freezing Temperatures and Visible Moisture.</p><p>Three Types -</p><ul><li>Clear Ice: Smooth ice that forms at temps just below freezing allowing it to spread across the surface, denser, heavier.</li><li>Rime Ice: Milky rough ice that forms at colder temps allowing the supercooled drops to freeze on impact.</li><li>Mixed Ice: Combination of Clear and Rime forms a temperatures in between the two.</li></ul><p>*Ice is reported as Trace, Light, Moderate, Severe. </p>",
-          "rawText": "Structural Icing requires Around Freezing Temperatures and Visible Moisture.\nThree Types -\nClear Ice: Smooth ice that forms at temps just below freezing allowing it to spread across the surface, denser, heavier.\nRime Ice: Milky rough ice that forms at colder temps allowing the supercooled drops to freeze on impact.\nMixed Ice: Combination of Clear and Rime forms a temperatures in between the two.\n*Ice is reported as Trace, Light, Moderate, Severe. \n",
+          "rawHtml": "<h3>What</h3><p>Structural Icing requires Around Freezing Temperatures and Visible Moisture.</p><p>Three Types -</p><ul><li>Clear Ice: Smooth ice that forms at temps just below freezing allowing it to spread across the surface, denser, heavier.</li><li>Rime Ice: Milky rough ice that forms at colder temps allowing the supercooled drops to freeze on impact.</li><li>Mixed Ice: Combination of Clear and Rime forms a temperatures in between the two.</li></ul><p>*Ice is reported as Trace, Light, Moderate, Severe. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nStructural Icing requires Around Freezing Temperatures and Visible Moisture.\nThree Types -\nClear Ice: Smooth ice that forms at temps just below freezing allowing it to spread across the surface, denser, heavier.\nRime Ice: Milky rough ice that forms at colder temps allowing the supercooled drops to freeze on impact.\nMixed Ice: Combination of Clear and Rime forms a temperatures in between the two.\n*Ice is reported as Trace, Light, Moderate, Severe. \n\nHow:\n\nWhy:\n",
           "title": "Icing",
           "type": "fill"
         },
@@ -3461,8 +3461,8 @@
               "word": "Steam"
             }
           ],
-          "rawHtml": "<p>Radiation Fog - Occurs on cool, clear, calm nights where the ground cools the air above it quicker than air higher up.</p><p>Advection Fog - Often occurs with sea breezes and happens when moist air gets pushed over a colder surface cooling it down to its dew point.</p><p>Upslope Fog - Occurs when wind forces moist air up say a mountain cooling the moist air to its dew point.</p><p>Steam Fog - Occurs when cold air moves over warm water.</p><p><br></p><p>*Fog Forms either when air cools to it's dew point to become fully saturated or moisture is added for it to become fully saturated.</p>",
-          "rawText": "Radiation Fog - Occurs on cool, clear, calm nights where the ground cools the air above it quicker than air higher up.\nAdvection Fog - Often occurs with sea breezes and happens when moist air gets pushed over a colder surface cooling it down to its dew point.\nUpslope Fog - Occurs when wind forces moist air up say a mountain cooling the moist air to its dew point.\nSteam Fog - Occurs when cold air moves over warm water.\n\n*Fog Forms either when air cools to it's dew point to become fully saturated or moisture is added for it to become fully saturated.\n",
+          "rawHtml": "<h3>What</h3><p>Radiation Fog - Occurs on cool, clear, calm nights where the ground cools the air above it quicker than air higher up.</p><p>Advection Fog - Often occurs with sea breezes and happens when moist air gets pushed over a colder surface cooling it down to its dew point.</p><p>Upslope Fog - Occurs when wind forces moist air up say a mountain cooling the moist air to its dew point.</p><p>Steam Fog - Occurs when cold air moves over warm water.</p><p><br></p><p>*Fog Forms either when air cools to it's dew point to become fully saturated or moisture is added for it to become fully saturated.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRadiation Fog - Occurs on cool, clear, calm nights where the ground cools the air above it quicker than air higher up.\nAdvection Fog - Often occurs with sea breezes and happens when moist air gets pushed over a colder surface cooling it down to its dew point.\nUpslope Fog - Occurs when wind forces moist air up say a mountain cooling the moist air to its dew point.\nSteam Fog - Occurs when cold air moves over warm water.\n\n*Fog Forms either when air cools to it's dew point to become fully saturated or moisture is added for it to become fully saturated.\n\nHow:\n\nWhy:\n",
           "title": "Fog",
           "type": "fill"
         }
@@ -3512,8 +3512,8 @@
               "word": "ATC."
             }
           ],
-          "rawHtml": "<p>Regulatory Airspace - Governed by the FAA, A, B, C, D, E and restricted and prohibited areas.</p><p>Non Regulatory Airspace - Operations that the FAA doesn't directly govern, MOAs, Warning and Alert Areas, CFAs, NWAs.</p><p>Four Types of Airspace - Controlled, Uncontrolled, Special Use, Other.</p><p>Controlled airspace Is that under the jurisdiction of ATC.</p>",
-          "rawText": "Regulatory Airspace - Governed by the FAA, A, B, C, D, E and restricted and prohibited areas.\nNon Regulatory Airspace - Operations that the FAA doesn't directly govern, MOAs, Warning and Alert Areas, CFAs, NWAs.\nFour Types of Airspace - Controlled, Uncontrolled, Special Use, Other.\nControlled airspace Is that under the jurisdiction of ATC.\n",
+          "rawHtml": "<h3>What</h3><p>Regulatory Airspace - Governed by the FAA, A, B, C, D, E and restricted and prohibited areas.</p><p>Non Regulatory Airspace - Operations that the FAA doesn't directly govern, MOAs, Warning and Alert Areas, CFAs, NWAs.</p><p>Four Types of Airspace - Controlled, Uncontrolled, Special Use, Other.</p><p>Controlled airspace Is that under the jurisdiction of ATC.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRegulatory Airspace - Governed by the FAA, A, B, C, D, E and restricted and prohibited areas.\nNon Regulatory Airspace - Operations that the FAA doesn't directly govern, MOAs, Warning and Alert Areas, CFAs, NWAs.\nFour Types of Airspace - Controlled, Uncontrolled, Special Use, Other.\nControlled airspace Is that under the jurisdiction of ATC.\n\nHow:\n\nWhy:\n",
           "title": "General Airspace",
           "type": "fill"
         },
@@ -3581,8 +3581,8 @@
               "word": "Out."
             }
           ],
-          "rawHtml": "<p>Starts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.</p><p>In Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92</p><p>Requirements -</p><p>Current Instrument rating in an IFR approved aircraft on an IFR flight plan.</p><p>Mode C transponder with ADS-B Out.</p>",
-          "rawText": "Starts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.\nIn Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92\nRequirements -\nCurrent Instrument rating in an IFR approved aircraft on an IFR flight plan.\nMode C transponder with ADS-B Out.\n",
+          "rawHtml": "<h3>What</h3><p>Starts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.</p><p>In Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92</p><p>Requirements -</p><p>Current Instrument rating in an IFR approved aircraft on an IFR flight plan.</p><p>Mode C transponder with ADS-B Out.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nStarts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.\nIn Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92\nRequirements -\nCurrent Instrument rating in an IFR approved aircraft on an IFR flight plan.\nMode C transponder with ADS-B Out.\n\nHow:\n\nWhy:\n",
           "title": "Class A Airspace",
           "type": "fill"
         },
@@ -3709,16 +3709,16 @@
               "y": 412
             }
           ],
-          "rawHtml": "<p>Starts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.</p><p>In Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92</p><p>Requirements -</p><p>Current Instrument rating in an IFR approved aircraft on an IFR flight plan.</p><p>Mode C transponder with ADS-B Out.</p><p>Airspeed less than Mach 1 above 10000ft MSL.</p>",
-          "rawText": "Starts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.\nIn Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92\nRequirements -\nCurrent Instrument rating in an IFR approved aircraft on an IFR flight plan.\nMode C transponder with ADS-B Out.\nAirspeed less than Mach 1 above 10000ft MSL.\n",
+          "rawHtml": "<h3>What</h3><p>Starts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.</p><p>In Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92</p><p>Requirements -</p><p>Current Instrument rating in an IFR approved aircraft on an IFR flight plan.</p><p>Mode C transponder with ADS-B Out.</p><p>Airspeed less than Mach 1 above 10000ft MSL.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nStarts at 18000 MSL and goes up to FL600 out to 12 NM off the coast.\nIn Class A you use Flight levels and pressure altitudes - set your altimeter to 29.92\nRequirements -\nCurrent Instrument rating in an IFR approved aircraft on an IFR flight plan.\nMode C transponder with ADS-B Out.\nAirspeed less than Mach 1 above 10000ft MSL.\n\nHow:\n\nWhy:\n",
           "title": "Class B Airspace",
           "type": "label"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p><strong style=\"color: rgb(107, 36, 178);\">Class C</strong></p><p>Tailored to traffic needs of primary airport. Usually has a 5 NM and 10 NM radius shelf and an 20 NM Outer Area.</p><p>Requirements to Enter</p><p>Two Way Radios, Mode C Transponder, ADS-B Out all required in and above Charlie Airspace.</p><p>Need to establish two way radio communications.</p><p>You Can get Class C Services from ATC within 20 NM outer area - Separation from IFR traffic etc.</p>",
-          "rawText": "Class C\nTailored to traffic needs of primary airport. Usually has a 5 NM and 10 NM radius shelf and an 20 NM Outer Area.\nRequirements to Enter\nTwo Way Radios, Mode C Transponder, ADS-B Out all required in and above Charlie Airspace.\nNeed to establish two way radio communications.\nYou Can get Class C Services from ATC within 20 NM outer area - Separation from IFR traffic etc.\n",
+          "rawHtml": "<h3>What</h3><p><strong style=\"color: rgb(107, 36, 178);\">Class C</strong></p><p>Tailored to traffic needs of primary airport. Usually has a 5 NM and 10 NM radius shelf and an 20 NM Outer Area.</p><p>Requirements to Enter</p><p>Two Way Radios, Mode C Transponder, ADS-B Out all required in and above Charlie Airspace.</p><p>Need to establish two way radio communications.</p><p>You Can get Class C Services from ATC within 20 NM outer area - Separation from IFR traffic etc.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nClass C\nTailored to traffic needs of primary airport. Usually has a 5 NM and 10 NM radius shelf and an 20 NM Outer Area.\nRequirements to Enter\nTwo Way Radios, Mode C Transponder, ADS-B Out all required in and above Charlie Airspace.\nNeed to establish two way radio communications.\nYou Can get Class C Services from ATC within 20 NM outer area - Separation from IFR traffic etc.\n\nHow:\n\nWhy:\n",
           "title": "Class C Airspace",
           "type": "fill"
         },
@@ -3746,8 +3746,8 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p><strong style=\"color: rgb(0, 71, 178);\">S</strong><strong>t</strong><strong style=\"color: rgb(0, 71, 178);\">a</strong><strong>n</strong><strong style=\"color: rgb(0, 71, 178);\">da</strong><strong>r</strong><strong style=\"color: rgb(0, 71, 178);\">d </strong><strong style=\"color: rgb(0, 41, 102);\">D</strong><strong>i</strong><strong style=\"color: rgb(0, 71, 178);\">me</strong><strong>n</strong><strong style=\"color: rgb(0, 71, 178);\">si</strong><strong>on</strong><strong style=\"color: rgb(0, 71, 178);\">s</strong></p><ul><li>4 NM Radius | 2500 AGL</li></ul><p><strong>Tower Closure</strong> —</p><p>Airspace reverts to class E or G.</p><p><strong>Entry Requirements</strong> —</p><ul><li>Two Way radios (Tail #)</li><li><em>Speed limit</em> for D and C within 2500 AGL and 4 NM is 200 KIAS.</li></ul>",
-          "rawText": "Standard Dimensions\n4 NM Radius | 2500 AGL\nTower Closure —\nAirspace reverts to class E or G.\nEntry Requirements —\nTwo Way radios (Tail #)\nSpeed limit for D and C within 2500 AGL and 4 NM is 200 KIAS.\n",
+          "rawHtml": "<h3>What</h3><p><strong style=\"color: rgb(0, 71, 178);\">S</strong><strong>t</strong><strong style=\"color: rgb(0, 71, 178);\">a</strong><strong>n</strong><strong style=\"color: rgb(0, 71, 178);\">da</strong><strong>r</strong><strong style=\"color: rgb(0, 71, 178);\">d </strong><strong style=\"color: rgb(0, 41, 102);\">D</strong><strong>i</strong><strong style=\"color: rgb(0, 71, 178);\">me</strong><strong>n</strong><strong style=\"color: rgb(0, 71, 178);\">si</strong><strong>on</strong><strong style=\"color: rgb(0, 71, 178);\">s</strong></p><ul><li>4 NM Radius | 2500 AGL</li></ul><p><strong>Tower Closure</strong> \u2014</p><p>Airspace reverts to class E or G.</p><p><strong>Entry Requirements</strong> \u2014</p><ul><li>Two Way radios (Tail #)</li><li><em>Speed limit</em> for D and C within 2500 AGL and 4 NM is 200 KIAS.</li></ul><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nStandard Dimensions\n4 NM Radius | 2500 AGL\nTower Closure \u2014\nAirspace reverts to class E or G.\nEntry Requirements \u2014\nTwo Way radios (Tail #)\nSpeed limit for D and C within 2500 AGL and 4 NM is 200 KIAS.\n\nHow:\n\nWhy:\n",
           "title": "Class D Airspace",
           "type": "fill"
         },
@@ -3841,7 +3841,7 @@
               "y": 110
             }
           ],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Class E Airspace",
           "type": "label"
         },
@@ -3853,8 +3853,8 @@
               "word": "uncontrolled"
             }
           ],
-          "rawHtml": "<p>Class G airspace is uncontrolled -&gt; ATC services are not available.</p><p>Could fly IMC in G without an IFR flight plan except that is considered 91.13 dangerous and reckless aviation so you can't.</p><p>If there is a towered class G airport you still must be in communication within 4NM and 2500 AGL.</p>",
-          "rawText": "Class G airspace is uncontrolled -> ATC services are not available.\nCould fly IMC in G without an IFR flight plan except that is considered 91.13 dangerous and reckless aviation so you can't.\nIf there is a towered class G airport you still must be in communication within 4NM and 2500 AGL.\n",
+          "rawHtml": "<h3>What</h3><p>Class G airspace is uncontrolled -&gt; ATC services are not available.</p><p>Could fly IMC in G without an IFR flight plan except that is considered 91.13 dangerous and reckless aviation so you can't.</p><p>If there is a towered class G airport you still must be in communication within 4NM and 2500 AGL.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nClass G airspace is uncontrolled -> ATC services are not available.\nCould fly IMC in G without an IFR flight plan except that is considered 91.13 dangerous and reckless aviation so you can't.\nIf there is a towered class G airport you still must be in communication within 4NM and 2500 AGL.\n\nHow:\n\nWhy:\n",
           "title": "Class G airspace",
           "type": "fill"
         },
@@ -3964,8 +3964,8 @@
               "word": "Area,"
             }
           ],
-          "rawHtml": "<p>Acronyms - MCPRAWN TTS</p><ul><li>Military Operation Area (MOA) - Used to separate IFR traffic from military operations and warn VFR traffic of possible high speed military activity.</li><li>Controlled Firing Areas (CFA) - Not Charted because there is a spotter looking out for aircraft to stop the potentially hazardous activities. </li><li>Prohibited Area - (P-40) Aircraft are prohibited to enter, examples include Camp David, National Mall, Heightened national security areas.</li><li>Restricted Area - (R-41) While active aircraft cannot enter, need permission from controlling agency when active. Contains activities hazardous to non participating aircraft. </li><li>Alert Area - Used to warn pilots of large volumes of training activity or unusual aerial activity.</li><li>Warning Area - (W-42) Extends starting 3 NM off the coast outwards and warns pilots of hazardous activity, use cation when entering.</li><li>National Security Area (NSA) - Where increased security is required for ground facilities, Pilots requested to avoid and sometimes prohibited based on NOTAMs.</li></ul><p>Intercept Procedures if you accidentally bust restricted airspace -</p><p>Squawk 7700, communicate on 121.5, rock wings to acknowledge instructions, follow the interceptor aircraft. </p><p>*Bonus <strong>ADIZ</strong> - Air Defense Identification Zone, must have to way radio and mode C transponder to identify yourself and be on flight plan.</p><p> <span style=\"color: rgb(230, 0, 0);\">T</span>RSA - Terminal Radar Service Area, Pilots encouraged to contact radio and get radar services.</p><p> <span style=\"color: rgb(230, 0, 0);\">T</span>emporary Flight Restrictions (TFR) - Avoid traffic congestion over sporting events, protect President, etc.</p><p> <strong style=\"color: rgb(230, 0, 0);\">S</strong><strong>FRA</strong> - Special Flight Rules Area, Unique air traffic control rules apply here.</p>",
-          "rawText": "Acronyms - MCPRAWN TTS\nMilitary Operation Area (MOA) - Used to separate IFR traffic from military operations and warn VFR traffic of possible high speed military activity.\nControlled Firing Areas (CFA) - Not Charted because there is a spotter looking out for aircraft to stop the potentially hazardous activities. \nProhibited Area - (P-40) Aircraft are prohibited to enter, examples include Camp David, National Mall, Heightened national security areas.\nRestricted Area - (R-41) While active aircraft cannot enter, need permission from controlling agency when active. Contains activities hazardous to non participating aircraft. \nAlert Area - Used to warn pilots of large volumes of training activity or unusual aerial activity.\nWarning Area - (W-42) Extends starting 3 NM off the coast outwards and warns pilots of hazardous activity, use cation when entering.\nNational Security Area (NSA) - Where increased security is required for ground facilities, Pilots requested to avoid and sometimes prohibited based on NOTAMs.\nIntercept Procedures if you accidentally bust restricted airspace -\nSquawk 7700, communicate on 121.5, rock wings to acknowledge instructions, follow the interceptor aircraft. \n*Bonus ADIZ - Air Defense Identification Zone, must have to way radio and mode C transponder to identify yourself and be on flight plan.\n TRSA - Terminal Radar Service Area, Pilots encouraged to contact radio and get radar services.\n Temporary Flight Restrictions (TFR) - Avoid traffic congestion over sporting events, protect President, etc.\n SFRA - Special Flight Rules Area, Unique air traffic control rules apply here.\n",
+          "rawHtml": "<h3>What</h3><p>Acronyms - MCPRAWN TTS</p><ul><li>Military Operation Area (MOA) - Used to separate IFR traffic from military operations and warn VFR traffic of possible high speed military activity.</li><li>Controlled Firing Areas (CFA) - Not Charted because there is a spotter looking out for aircraft to stop the potentially hazardous activities. </li><li>Prohibited Area - (P-40) Aircraft are prohibited to enter, examples include Camp David, National Mall, Heightened national security areas.</li><li>Restricted Area - (R-41) While active aircraft cannot enter, need permission from controlling agency when active. Contains activities hazardous to non participating aircraft. </li><li>Alert Area - Used to warn pilots of large volumes of training activity or unusual aerial activity.</li><li>Warning Area - (W-42) Extends starting 3 NM off the coast outwards and warns pilots of hazardous activity, use cation when entering.</li><li>National Security Area (NSA) - Where increased security is required for ground facilities, Pilots requested to avoid and sometimes prohibited based on NOTAMs.</li></ul><p>Intercept Procedures if you accidentally bust restricted airspace -</p><p>Squawk 7700, communicate on 121.5, rock wings to acknowledge instructions, follow the interceptor aircraft. </p><p>*Bonus <strong>ADIZ</strong> - Air Defense Identification Zone, must have to way radio and mode C transponder to identify yourself and be on flight plan.</p><p> <span style=\"color: rgb(230, 0, 0);\">T</span>RSA - Terminal Radar Service Area, Pilots encouraged to contact radio and get radar services.</p><p> <span style=\"color: rgb(230, 0, 0);\">T</span>emporary Flight Restrictions (TFR) - Avoid traffic congestion over sporting events, protect President, etc.</p><p> <strong style=\"color: rgb(230, 0, 0);\">S</strong><strong>FRA</strong> - Special Flight Rules Area, Unique air traffic control rules apply here.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAcronyms - MCPRAWN TTS\nMilitary Operation Area (MOA) - Used to separate IFR traffic from military operations and warn VFR traffic of possible high speed military activity.\nControlled Firing Areas (CFA) - Not Charted because there is a spotter looking out for aircraft to stop the potentially hazardous activities. \nProhibited Area - (P-40) Aircraft are prohibited to enter, examples include Camp David, National Mall, Heightened national security areas.\nRestricted Area - (R-41) While active aircraft cannot enter, need permission from controlling agency when active. Contains activities hazardous to non participating aircraft. \nAlert Area - Used to warn pilots of large volumes of training activity or unusual aerial activity.\nWarning Area - (W-42) Extends starting 3 NM off the coast outwards and warns pilots of hazardous activity, use cation when entering.\nNational Security Area (NSA) - Where increased security is required for ground facilities, Pilots requested to avoid and sometimes prohibited based on NOTAMs.\nIntercept Procedures if you accidentally bust restricted airspace -\nSquawk 7700, communicate on 121.5, rock wings to acknowledge instructions, follow the interceptor aircraft. \n*Bonus ADIZ - Air Defense Identification Zone, must have to way radio and mode C transponder to identify yourself and be on flight plan.\n TRSA - Terminal Radar Service Area, Pilots encouraged to contact radio and get radar services.\n Temporary Flight Restrictions (TFR) - Avoid traffic congestion over sporting events, protect President, etc.\n SFRA - Special Flight Rules Area, Unique air traffic control rules apply here.\n\nHow:\n\nWhy:\n",
           "title": "Special Use Airspace",
           "type": "fill"
         },
@@ -3993,23 +3993,23 @@
               "occ": 2
             }
           ],
-          "rawHtml": "<p>Minimum Safe Altitudes 91.119</p><p>Congested Areas - 1000 ft above the highest obstacle in a 2000 ft radius.</p><p>Sparsely Populated/ Water - 500 ft above any person vehicle or structure if there are any.</p><p>Other - 500 ft above the surface.</p><p>Always have to be able to make an emergency landing without undue hazard to persons or property on the surface.</p><p>*Pilots are strongly requested to stay at least 2000 ft above the surface of Wildlife Refuges.</p>",
-          "rawText": "Minimum Safe Altitudes 91.119\nCongested Areas - 1000 ft above the highest obstacle in a 2000 ft radius.\nSparsely Populated/ Water - 500 ft above any person vehicle or structure if there are any.\nOther - 500 ft above the surface.\nAlways have to be able to make an emergency landing without undue hazard to persons or property on the surface.\n*Pilots are strongly requested to stay at least 2000 ft above the surface of Wildlife Refuges.\n",
+          "rawHtml": "<h3>What</h3><p>Minimum Safe Altitudes 91.119</p><p>Congested Areas - 1000 ft above the highest obstacle in a 2000 ft radius.</p><p>Sparsely Populated/ Water - 500 ft above any person vehicle or structure if there are any.</p><p>Other - 500 ft above the surface.</p><p>Always have to be able to make an emergency landing without undue hazard to persons or property on the surface.</p><p>*Pilots are strongly requested to stay at least 2000 ft above the surface of Wildlife Refuges.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nMinimum Safe Altitudes 91.119\nCongested Areas - 1000 ft above the highest obstacle in a 2000 ft radius.\nSparsely Populated/ Water - 500 ft above any person vehicle or structure if there are any.\nOther - 500 ft above the surface.\nAlways have to be able to make an emergency landing without undue hazard to persons or property on the surface.\n*Pilots are strongly requested to stay at least 2000 ft above the surface of Wildlife Refuges.\n\nHow:\n\nWhy:\n",
           "title": "Minimum Altitudes",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Sectional Charts",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Flight Service Stations - Universal frequency 122.2</p><p>Remote Communications Outlet - </p><p><br></p>",
-          "rawText": "Flight Service Stations - Universal frequency 122.2\nRemote Communications Outlet - \n\n",
+          "rawHtml": "<h3>What</h3><p>Flight Service Stations - Universal frequency 122.2</p><p>Remote Communications Outlet - </p><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nFlight Service Stations - Universal frequency 122.2\nRemote Communications Outlet - \n\nHow:\n\nWhy:\n",
           "title": "Stations",
           "type": "fill"
         },
@@ -4025,16 +4025,16 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p>Your Altitude above sea level (MSL) adjusted for standard pressure of 29.92</p><p>Found With: Standard altimeter setting - Current Setting * 1000 + Field Elevation, Set 29.92 into Kollsman Window on altimeter.</p><p>When traveling from high to low pressures or temperatures remember this phrase for what your altimeter will read -</p><p>\" High to Low look Out Below \".</p><p>In Cold Weather and low pressure you will be lower to the ground than what the altimeter makes you think.</p>",
-          "rawText": "Your Altitude above sea level (MSL) adjusted for standard pressure of 29.92\nFound With: Standard altimeter setting - Current Setting * 1000 + Field Elevation, Set 29.92 into Kollsman Window on altimeter.\nWhen traveling from high to low pressures or temperatures remember this phrase for what your altimeter will read -\n\" High to Low look Out Below \".\nIn Cold Weather and low pressure you will be lower to the ground than what the altimeter makes you think.\n",
+          "rawHtml": "<h3>What</h3><p>Your Altitude above sea level (MSL) adjusted for standard pressure of 29.92</p><p>Found With: Standard altimeter setting - Current Setting * 1000 + Field Elevation, Set 29.92 into Kollsman Window on altimeter.</p><p>When traveling from high to low pressures or temperatures remember this phrase for what your altimeter will read -</p><p>\" High to Low look Out Below \".</p><p>In Cold Weather and low pressure you will be lower to the ground than what the altimeter makes you think.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYour Altitude above sea level (MSL) adjusted for standard pressure of 29.92\nFound With: Standard altimeter setting - Current Setting * 1000 + Field Elevation, Set 29.92 into Kollsman Window on altimeter.\nWhen traveling from high to low pressures or temperatures remember this phrase for what your altimeter will read -\n\" High to Low look Out Below \".\nIn Cold Weather and low pressure you will be lower to the ground than what the altimeter makes you think.\n\nHow:\n\nWhy:\n",
           "title": "Pressure Altitude",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>The altitude your plane feels like it's flying at.</p><p>Pressure altitude corrected for non standard temperature.</p><p>A high density altitude actually means less dense air so worse performance.</p><p>The performance is worse because there are fewer air molecules for the engine, prop, and wings to use for thrust and list.</p><p><br></p>",
-          "rawText": "The altitude your plane feels like it's flying at.\nPressure altitude corrected for non standard temperature.\nA high density altitude actually means less dense air so worse performance.\nThe performance is worse because there are fewer air molecules for the engine, prop, and wings to use for thrust and list.\n\n",
+          "rawHtml": "<h3>What</h3><p>The altitude your plane feels like it's flying at.</p><p>Pressure altitude corrected for non standard temperature.</p><p>A high density altitude actually means less dense air so worse performance.</p><p>The performance is worse because there are fewer air molecules for the engine, prop, and wings to use for thrust and list.</p><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nThe altitude your plane feels like it's flying at.\nPressure altitude corrected for non standard temperature.\nA high density altitude actually means less dense air so worse performance.\nThe performance is worse because there are fewer air molecules for the engine, prop, and wings to use for thrust and list.\n\nHow:\n\nWhy:\n",
           "title": "Density Altitude",
           "type": "fill"
         },
@@ -4086,31 +4086,31 @@
               "word": "cruise"
             }
           ],
-          "rawHtml": "<p>Forward CG: Increased Stall Speed but easier recovery, Slower Cruise speed, more stable but less controllable.</p><p>*Because the horizontal tail surfaces actually create negative lift so with forward CG more of that negative lift is being created</p><p> requiring the wings to create more lift with a higher AOA.</p><p>Rearward CG: Opposites - Decreased stall speed, higher cruise speed, less stable but more maneuverable.</p><p>* A Heavier plane overall has Higher Stall speeds, slower cruise speeds, longer landing and takeoff rolls.</p>",
-          "rawText": "Forward CG: Increased Stall Speed but easier recovery, Slower Cruise speed, more stable but less controllable.\n*Because the horizontal tail surfaces actually create negative lift so with forward CG more of that negative lift is being created\n requiring the wings to create more lift with a higher AOA.\nRearward CG: Opposites - Decreased stall speed, higher cruise speed, less stable but more maneuverable.\n* A Heavier plane overall has Higher Stall speeds, slower cruise speeds, longer landing and takeoff rolls.\n",
+          "rawHtml": "<h3>What</h3><p>Forward CG: Increased Stall Speed but easier recovery, Slower Cruise speed, more stable but less controllable.</p><p>*Because the horizontal tail surfaces actually create negative lift so with forward CG more of that negative lift is being created</p><p> requiring the wings to create more lift with a higher AOA.</p><p>Rearward CG: Opposites - Decreased stall speed, higher cruise speed, less stable but more maneuverable.</p><p>* A Heavier plane overall has Higher Stall speeds, slower cruise speeds, longer landing and takeoff rolls.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nForward CG: Increased Stall Speed but easier recovery, Slower Cruise speed, more stable but less controllable.\n*Because the horizontal tail surfaces actually create negative lift so with forward CG more of that negative lift is being created\n requiring the wings to create more lift with a higher AOA.\nRearward CG: Opposites - Decreased stall speed, higher cruise speed, less stable but more maneuverable.\n* A Heavier plane overall has Higher Stall speeds, slower cruise speeds, longer landing and takeoff rolls.\n\nHow:\n\nWhy:\n",
           "title": "Center of Gravity Effects",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Weight Shift Formula: (Amount of weight shifted) / Total Weight = Change of CG / Distance Weight is shifted</p><p><br></p>",
-          "rawText": "Weight Shift Formula: (Amount of weight shifted) / Total Weight = Change of CG / Distance Weight is shifted\n\n",
+          "rawHtml": "<h3>What</h3><p>Weight Shift Formula: (Amount of weight shifted) / Total Weight = Change of CG / Distance Weight is shifted</p><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWeight Shift Formula: (Amount of weight shifted) / Total Weight = Change of CG / Distance Weight is shifted\n\nHow:\n\nWhy:\n",
           "title": "Weight and Balance",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "V Speeds",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Rotating Beacons </p><p>Runway Edge Lights = White | Last 2000ft = Yellow</p><p>Runway Centerline Lights = White | Last 3000ft = Alternating Red/White | Last 1000ft = Red</p><p>Taxiway Edge Lights = Blue</p><p>Threshold Lights = Bar of green lights</p><p>REIL = White strobes flashing on each side of the end of runway</p>",
-          "rawText": "Rotating Beacons \nRunway Edge Lights = White | Last 2000ft = Yellow\nRunway Centerline Lights = White | Last 3000ft = Alternating Red/White | Last 1000ft = Red\nTaxiway Edge Lights = Blue\nThreshold Lights = Bar of green lights\nREIL = White strobes flashing on each side of the end of runway\n",
+          "rawHtml": "<h3>What</h3><p>Rotating Beacons </p><p>Runway Edge Lights = White | Last 2000ft = Yellow</p><p>Runway Centerline Lights = White | Last 3000ft = Alternating Red/White | Last 1000ft = Red</p><p>Taxiway Edge Lights = Blue</p><p>Threshold Lights = Bar of green lights</p><p>REIL = White strobes flashing on each side of the end of runway</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nRotating Beacons \nRunway Edge Lights = White | Last 2000ft = Yellow\nRunway Centerline Lights = White | Last 3000ft = Alternating Red/White | Last 1000ft = Red\nTaxiway Edge Lights = Blue\nThreshold Lights = Bar of green lights\nREIL = White strobes flashing on each side of the end of runway\n\nHow:\n\nWhy:\n",
           "title": "Airport Lights",
           "type": "fill"
         },
@@ -4134,8 +4134,8 @@
               "word": "forward"
             }
           ],
-          "rawHtml": "<p>Occurs from uncoordinated stalls where one wing is stalled more than the other.</p><p>Fours stages to a spin - Entry, Incipient, Fully developed, Recovery.</p><p>Incipient - First 2-4 turns where aerodynamic forces have not yet reached a balance.</p><p>Fully Developed - Rate of rotation, descent, and airspeed are all stabilized in a near vertical downward path. </p><p>Recover - PARE</p><p>Power Idle</p><p>Ailerons Neutral</p><p>Rudder Opposite of spin</p><p>Elevator move briskly forward to break stall</p><p>*Once established a spin can lose altitude at 10000ft per minute, spin itself is 1G recovery is 2.5G</p>",
-          "rawText": "Occurs from uncoordinated stalls where one wing is stalled more than the other.\nFours stages to a spin - Entry, Incipient, Fully developed, Recovery.\nIncipient - First 2-4 turns where aerodynamic forces have not yet reached a balance.\nFully Developed - Rate of rotation, descent, and airspeed are all stabilized in a near vertical downward path. \nRecover - PARE\nPower Idle\nAilerons Neutral\nRudder Opposite of spin\nElevator move briskly forward to break stall\n*Once established a spin can lose altitude at 10000ft per minute, spin itself is 1G recovery is 2.5G\n",
+          "rawHtml": "<h3>What</h3><p>Occurs from uncoordinated stalls where one wing is stalled more than the other.</p><p>Fours stages to a spin - Entry, Incipient, Fully developed, Recovery.</p><p>Incipient - First 2-4 turns where aerodynamic forces have not yet reached a balance.</p><p>Fully Developed - Rate of rotation, descent, and airspeed are all stabilized in a near vertical downward path. </p><p>Recover - PARE</p><p>Power Idle</p><p>Ailerons Neutral</p><p>Rudder Opposite of spin</p><p>Elevator move briskly forward to break stall</p><p>*Once established a spin can lose altitude at 10000ft per minute, spin itself is 1G recovery is 2.5G</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nOccurs from uncoordinated stalls where one wing is stalled more than the other.\nFours stages to a spin - Entry, Incipient, Fully developed, Recovery.\nIncipient - First 2-4 turns where aerodynamic forces have not yet reached a balance.\nFully Developed - Rate of rotation, descent, and airspeed are all stabilized in a near vertical downward path. \nRecover - PARE\nPower Idle\nAilerons Neutral\nRudder Opposite of spin\nElevator move briskly forward to break stall\n*Once established a spin can lose altitude at 10000ft per minute, spin itself is 1G recovery is 2.5G\n\nHow:\n\nWhy:\n",
           "title": "Spins",
           "type": "fill"
         },
@@ -4175,15 +4175,15 @@
               "word": "all"
             }
           ],
-          "rawHtml": "<p>Above 12500 MSL required use by flight crew members for more than 30 minutes</p><p>Above 14000 MSL required use by flight crew members any time.</p><p>Above 15000 MSL required to supply all occupants with supplemental oxygen.</p><p>*At night vision it is recommended above 5000 MSL because vision erodes rapidly and pilots are more tired</p><p> During the Day it is still recommended above 10000 MSL</p><p>Altitudes are actually cabin pressure altitudes and can be lower than MSL with lower than standard altimeter settings</p>",
-          "rawText": "Above 12500 MSL required use by flight crew members for more than 30 minutes\nAbove 14000 MSL required use by flight crew members any time.\nAbove 15000 MSL required to supply all occupants with supplemental oxygen.\n*At night vision it is recommended above 5000 MSL because vision erodes rapidly and pilots are more tired\n During the Day it is still recommended above 10000 MSL\nAltitudes are actually cabin pressure altitudes and can be lower than MSL with lower than standard altimeter settings\n",
+          "rawHtml": "<h3>What</h3><p>Above 12500 MSL required use by flight crew members for more than 30 minutes</p><p>Above 14000 MSL required use by flight crew members any time.</p><p>Above 15000 MSL required to supply all occupants with supplemental oxygen.</p><p>*At night vision it is recommended above 5000 MSL because vision erodes rapidly and pilots are more tired</p><p> During the Day it is still recommended above 10000 MSL</p><p>Altitudes are actually cabin pressure altitudes and can be lower than MSL with lower than standard altimeter settings</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAbove 12500 MSL required use by flight crew members for more than 30 minutes\nAbove 14000 MSL required use by flight crew members any time.\nAbove 15000 MSL required to supply all occupants with supplemental oxygen.\n*At night vision it is recommended above 5000 MSL because vision erodes rapidly and pilots are more tired\n During the Day it is still recommended above 10000 MSL\nAltitudes are actually cabin pressure altitudes and can be lower than MSL with lower than standard altimeter settings\n\nHow:\n\nWhy:\n",
           "title": "Supplemental Oxygen Requirements",
           "type": "fill"
         },
         {
           "type": "fill",
           "title": "Lost Comms",
-          "rawText": ""
+          "rawText": "What:\n\nHow:\n\nWhy:\n"
         }
       ],
       "color": "#53d5fd"
@@ -4243,8 +4243,8 @@
               "word": "orientation"
             }
           ],
-          "rawHtml": "<p>Gyroscopic Instruments</p><p>Power Sources/Principles</p><p>\t• Rigidity in Space / Vacuum: Attitude Indicator, Heading Indicator</p><p>\t• Precession / Electricity : Turn Coordinator (also rigidity in space)</p><p>Rigidity in Space : A spinning disk (like a gyro) resists changes to and maintains its orientation in space.</p><p>Precession : Force applied to a spinning disk is deflected 90 degrees in the direction of rotation.</p>",
-          "rawText": "Gyroscopic Instruments\nPower Sources/Principles\n\t• Rigidity in Space / Vacuum: Attitude Indicator, Heading Indicator\n\t• Precession / Electricity : Turn Coordinator (also rigidity in space)\nRigidity in Space : A spinning disk (like a gyro) resists changes to and maintains its orientation in space.\nPrecession : Force applied to a spinning disk is deflected 90 degrees in the direction of rotation.\n",
+          "rawHtml": "<h3>What</h3><p>Gyroscopic Instruments</p><p>Power Sources/Principles</p><p>\t\u2022 Rigidity in Space / Vacuum: Attitude Indicator, Heading Indicator</p><p>\t\u2022 Precession / Electricity : Turn Coordinator (also rigidity in space)</p><p>Rigidity in Space : A spinning disk (like a gyro) resists changes to and maintains its orientation in space.</p><p>Precession : Force applied to a spinning disk is deflected 90 degrees in the direction of rotation.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nGyroscopic Instruments\nPower Sources/Principles\n\t\u2022 Rigidity in Space / Vacuum: Attitude Indicator, Heading Indicator\n\t\u2022 Precession / Electricity : Turn Coordinator (also rigidity in space)\nRigidity in Space : A spinning disk (like a gyro) resists changes to and maintains its orientation in space.\nPrecession : Force applied to a spinning disk is deflected 90 degrees in the direction of rotation.\n\nHow:\n\nWhy:\n",
           "title": "",
           "type": "fill"
         },
@@ -4401,8 +4401,8 @@
               "y": 6
             }
           ],
-          "rawHtml": "<p>You turn on the battery to supply electricity to the starter and auxiliary pump.</p><p>Prime the engine to get some fuel in the cylinders.</p><p>The starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,</p><p>This turns the crankshaft which is connected through gears to the magnetos</p><p>these then start generating electricity to the spark plugs to ignite the fuel in the cylinders. </p><p><br></p><p>Impulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first</p><p>to generate enough electricity for the spark plugs.</p>",
-          "rawText": "You turn on the battery to supply electricity to the starter and auxiliary pump.\nPrime the engine to get some fuel in the cylinders.\nThe starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,\nThis turns the crankshaft which is connected through gears to the magnetos\nthese then start generating electricity to the spark plugs to ignite the fuel in the cylinders. \n\nImpulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first\nto generate enough electricity for the spark plugs.\n",
+          "rawHtml": "<h3>What</h3><p>You turn on the battery to supply electricity to the starter and auxiliary pump.</p><p>Prime the engine to get some fuel in the cylinders.</p><p>The starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,</p><p>This turns the crankshaft which is connected through gears to the magnetos</p><p>these then start generating electricity to the spark plugs to ignite the fuel in the cylinders. </p><p><br></p><p>Impulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first</p><p>to generate enough electricity for the spark plugs.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYou turn on the battery to supply electricity to the starter and auxiliary pump.\nPrime the engine to get some fuel in the cylinders.\nThe starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,\nThis turns the crankshaft which is connected through gears to the magnetos\nthese then start generating electricity to the spark plugs to ignite the fuel in the cylinders. \n\nImpulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first\nto generate enough electricity for the spark plugs.\n\nHow:\n\nWhy:\n",
           "title": "Gyroscopic Intruments",
           "type": "label"
         },
@@ -4546,16 +4546,16 @@
               "y": 6
             }
           ],
-          "rawHtml": "<p>Turn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the</p><p>Rate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. </p>",
-          "rawText": "Turn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the\nRate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. \n",
+          "rawHtml": "<h3>What</h3><p>Turn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the</p><p>Rate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTurn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the\nRate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. \n\nHow:\n\nWhy:\n",
           "title": "Pitot Static System",
           "type": "label"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Turn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the</p><p>Rate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. </p>",
-          "rawText": "Turn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the\nRate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. ",
+          "rawHtml": "<h3>What</h3><p>Turn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the</p><p>Rate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTurn Coordinator: Canted Horizontally mounted Gyro that is powered by electricity, the 30 degree canted angle allows it to sense the\nRate of Roll while still also giving the Rate of Turn like a Turn and Slip Indicator. \n\nHow:\n\nWhy:\n",
           "title": "Turn Coordinator",
           "type": "fill"
         },
@@ -4591,16 +4591,16 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p>Uses a Gyro mounted horizontally that spins from a Vacuum Pump and maintains the Horizons attitude using the principle rigidity in space.</p><p><br></p><p>Avoids precession errors by having pendulous vanes that swing and cover air holes.</p>",
-          "rawText": "Uses a Gyro mounted horizontally that spins from a Vacuum Pump and maintains the Horizons attitude using the principle rigidity in space.\n\nAvoids precession errors by having pendulous vanes that swing and cover air holes.\n",
+          "rawHtml": "<h3>What</h3><p>Uses a Gyro mounted horizontally that spins from a Vacuum Pump and maintains the Horizons attitude using the principle rigidity in space.</p><p><br></p><p>Avoids precession errors by having pendulous vanes that swing and cover air holes.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nUses a Gyro mounted horizontally that spins from a Vacuum Pump and maintains the Horizons attitude using the principle rigidity in space.\n\nAvoids precession errors by having pendulous vanes that swing and cover air holes.\n\nHow:\n\nWhy:\n",
           "title": "Attitude Indicator",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Heading Indicator: Vertically mounted Gyro that spins from a Vacuum Pump and maintains the aircraft heading orientation, </p><p>has to be adjusted to the current heading based on the magnetic compass initially and then every 15 mins</p><p> to account for precession throwing it off. </p>",
-          "rawText": "Heading Indicator: Vertically mounted Gyro that spins from a Vacuum Pump and maintains the aircraft heading orientation, \nhas to be adjusted to the current heading based on the magnetic compass initially and then every 15 mins\n to account for precession throwing it off. ",
+          "rawHtml": "<h3>What</h3><p>Heading Indicator: Vertically mounted Gyro that spins from a Vacuum Pump and maintains the aircraft heading orientation, </p><p>has to be adjusted to the current heading based on the magnetic compass initially and then every 15 mins</p><p> to account for precession throwing it off. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nHeading Indicator: Vertically mounted Gyro that spins from a Vacuum Pump and maintains the aircraft heading orientation, \nhas to be adjusted to the current heading based on the magnetic compass initially and then every 15 mins\n to account for precession throwing it off. \n\nHow:\n\nWhy:\n",
           "title": "Heading Indicator",
           "type": "fill"
         },
@@ -4636,16 +4636,16 @@
               "word": "tilt"
             }
           ],
-          "rawHtml": "<p>Attitude Heading Reference System (AHRS)</p><p>Replaces the Gyroscopic System with micro-electronic Gyros that use vibrations, accelerometers that use gravitational force, and a magnetometer or flux valve that measures the Earth's magnetic field strength and direction. Rate and tilt sensors.</p>",
-          "rawText": "Attitude Heading Reference System (AHRS)\nReplaces the Gyroscopic System with micro-electronic Gyros that use vibrations, accelerometers that use gravitational force, and a magnetometer or flux valve that measures the Earth's magnetic field strength and direction. Rate and tilt sensors.",
+          "rawHtml": "<h3>What</h3><p>Attitude Heading Reference System (AHRS)</p><p>Replaces the Gyroscopic System with micro-electronic Gyros that use vibrations, accelerometers that use gravitational force, and a magnetometer or flux valve that measures the Earth's magnetic field strength and direction. Rate and tilt sensors.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAttitude Heading Reference System (AHRS)\nReplaces the Gyroscopic System with micro-electronic Gyros that use vibrations, accelerometers that use gravitational force, and a magnetometer or flux valve that measures the Earth's magnetic field strength and direction. Rate and tilt sensors.\n\nHow:\n\nWhy:\n",
           "title": "",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>PFD, MFD, Audio Panel, ADC, AHRS, Magnetometer, Datalink, etc.</p><p>There are two integrated avionics units and both would have to fail for us to lose nav and coms.</p><p>Potential Limitations of the G1000 is a tendency to over control the aircraft. Databases can be expired if not checked,</p><p>and it can make people focus to much inside the plane and not look outside. </p>",
-          "rawText": "PFD, MFD, Audio Panel, ADC, AHRS, Magnetometer, Datalink, etc.\nThere are two integrated avionics units and both would have to fail for us to lose nav and coms.\nPotential Limitations of the G1000 is a tendency to over control the aircraft. Databases can be expired if not checked,\nand it can make people focus to much inside the plane and not look outside. \n",
+          "rawHtml": "<h3>What</h3><p>PFD, MFD, Audio Panel, ADC, AHRS, Magnetometer, Datalink, etc.</p><p>There are two integrated avionics units and both would have to fail for us to lose nav and coms.</p><p>Potential Limitations of the G1000 is a tendency to over control the aircraft. Databases can be expired if not checked,</p><p>and it can make people focus to much inside the plane and not look outside. </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPFD, MFD, Audio Panel, ADC, AHRS, Magnetometer, Datalink, etc.\nThere are two integrated avionics units and both would have to fail for us to lose nav and coms.\nPotential Limitations of the G1000 is a tendency to over control the aircraft. Databases can be expired if not checked,\nand it can make people focus to much inside the plane and not look outside. \n\nHow:\n\nWhy:\n",
           "title": "LRUs",
           "type": "fill"
         },
@@ -4697,8 +4697,8 @@
               "word": "Errors"
             }
           ],
-          "rawHtml": "<p>Two small magnets inside a kerosene liquid attached to a pivot mount allowing them to move freely and remain aligned with magnetic north.</p><p>The vertical line showing your heading is the lubber line.</p><p>The fluid dampens oscillations and takes weight off the pivot.</p><p>Errors associates with the magnetic compass: Acronym - VDMONA</p><p>Variation - Difference between True and Magnetic North, Corrected for with Isogonic lines on sectional charts</p><p>Deviation - Magnetic fields within the aircraft messing with it's orientation</p><p>Magnetic Dip - Tendency to dip down to align with the vertical aspect of the magnetic lines that at the poles go straight down.</p><p>Oscillation - Erratic readings during turbulence from it bouncing around.</p><p>Northerly Turning Errors - UNOS, Undershoot North and Overshoot South: When turning to the North you undershoot the turn and vice versa</p><p>Acceleration Errors - ANDS, Accelerate North and Decelerate South: When not already facing North or South when you accelerate it will point North and vice versa</p>",
-          "rawText": "Two small magnets inside a kerosene liquid attached to a pivot mount allowing them to move freely and remain aligned with magnetic north.\nThe vertical line showing your heading is the lubber line.\nThe fluid dampens oscillations and takes weight off the pivot.\nErrors associates with the magnetic compass: Acronym - VDMONA\nVariation - Difference between True and Magnetic North, Corrected for with Isogonic lines on sectional charts\nDeviation - Magnetic fields within the aircraft messing with it's orientation\nMagnetic Dip - Tendency to dip down to align with the vertical aspect of the magnetic lines that at the poles go straight down.\nOscillation - Erratic readings during turbulence from it bouncing around.\nNortherly Turning Errors - UNOS, Undershoot North and Overshoot South: When turning to the North you undershoot the turn and vice versa\nAcceleration Errors - ANDS, Accelerate North and Decelerate South: When not already facing North or South when you accelerate it will point North and vice versa\n",
+          "rawHtml": "<h3>What</h3><p>Two small magnets inside a kerosene liquid attached to a pivot mount allowing them to move freely and remain aligned with magnetic north.</p><p>The vertical line showing your heading is the lubber line.</p><p>The fluid dampens oscillations and takes weight off the pivot.</p><p>Errors associates with the magnetic compass: Acronym - VDMONA</p><p>Variation - Difference between True and Magnetic North, Corrected for with Isogonic lines on sectional charts</p><p>Deviation - Magnetic fields within the aircraft messing with it's orientation</p><p>Magnetic Dip - Tendency to dip down to align with the vertical aspect of the magnetic lines that at the poles go straight down.</p><p>Oscillation - Erratic readings during turbulence from it bouncing around.</p><p>Northerly Turning Errors - UNOS, Undershoot North and Overshoot South: When turning to the North you undershoot the turn and vice versa</p><p>Acceleration Errors - ANDS, Accelerate North and Decelerate South: When not already facing North or South when you accelerate it will point North and vice versa</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTwo small magnets inside a kerosene liquid attached to a pivot mount allowing them to move freely and remain aligned with magnetic north.\nThe vertical line showing your heading is the lubber line.\nThe fluid dampens oscillations and takes weight off the pivot.\nErrors associates with the magnetic compass: Acronym - VDMONA\nVariation - Difference between True and Magnetic North, Corrected for with Isogonic lines on sectional charts\nDeviation - Magnetic fields within the aircraft messing with it's orientation\nMagnetic Dip - Tendency to dip down to align with the vertical aspect of the magnetic lines that at the poles go straight down.\nOscillation - Erratic readings during turbulence from it bouncing around.\nNortherly Turning Errors - UNOS, Undershoot North and Overshoot South: When turning to the North you undershoot the turn and vice versa\nAcceleration Errors - ANDS, Accelerate North and Decelerate South: When not already facing North or South when you accelerate it will point North and vice versa\n\nHow:\n\nWhy:\n",
           "title": "Magnetic Compass",
           "type": "fill"
         }
@@ -4768,8 +4768,8 @@
               "word": "coupler"
             }
           ],
-          "rawHtml": "<p>You turn on the battery to supply electricity to the starter and auxiliary pump.</p><p>Prime the engine to get some fuel in the cylinders.</p><p>The starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,</p><p>This turns the crankshaft which is connected through gears to the magnetos</p><p>these then start generating electricity to the spark plugs to ignite the fuel in the cylinders. </p><p><br></p><p>Impulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first</p><p>to generate enough electricity for the spark plugs.</p>",
-          "rawText": "You turn on the battery to supply electricity to the starter and auxiliary pump.\nPrime the engine to get some fuel in the cylinders.\nThe starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,\nThis turns the crankshaft which is connected through gears to the magnetos\nthese then start generating electricity to the spark plugs to ignite the fuel in the cylinders. \n\nImpulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first\nto generate enough electricity for the spark plugs.\n",
+          "rawHtml": "<h3>What</h3><p>You turn on the battery to supply electricity to the starter and auxiliary pump.</p><p>Prime the engine to get some fuel in the cylinders.</p><p>The starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,</p><p>This turns the crankshaft which is connected through gears to the magnetos</p><p>these then start generating electricity to the spark plugs to ignite the fuel in the cylinders. </p><p><br></p><p>Impulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first</p><p>to generate enough electricity for the spark plugs.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYou turn on the battery to supply electricity to the starter and auxiliary pump.\nPrime the engine to get some fuel in the cylinders.\nThe starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,\nThis turns the crankshaft which is connected through gears to the magnetos\nthese then start generating electricity to the spark plugs to ignite the fuel in the cylinders. \n\nImpulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first\nto generate enough electricity for the spark plugs.\n\nHow:\n\nWhy:\n",
           "title": "Starter System",
           "type": "fill"
         },
@@ -4931,8 +4931,8 @@
               "y": 14
             }
           ],
-          "rawHtml": "<p>You turn on the battery to supply electricity to the starter and auxiliary pump.</p><p>Prime the engine to get some fuel in the cylinders.</p><p>The starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,</p><p>This turns the crankshaft which is connected through gears to the magnetos</p><p>these then start generating electricity to the spark plugs to ignite the fuel in the cylinders. </p><p><br></p><p>Impulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first</p><p>to generate enough electricity for the spark plugs.</p>",
-          "rawText": "You turn on the battery to supply electricity to the starter and auxiliary pump.\nPrime the engine to get some fuel in the cylinders.\nThe starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,\nThis turns the crankshaft which is connected through gears to the magnetos\nthese then start generating electricity to the spark plugs to ignite the fuel in the cylinders. \n\nImpulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first\nto generate enough electricity for the spark plugs.\n",
+          "rawHtml": "<h3>What</h3><p>You turn on the battery to supply electricity to the starter and auxiliary pump.</p><p>Prime the engine to get some fuel in the cylinders.</p><p>The starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,</p><p>This turns the crankshaft which is connected through gears to the magnetos</p><p>these then start generating electricity to the spark plugs to ignite the fuel in the cylinders. </p><p><br></p><p>Impulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first</p><p>to generate enough electricity for the spark plugs.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYou turn on the battery to supply electricity to the starter and auxiliary pump.\nPrime the engine to get some fuel in the cylinders.\nThe starter extends a gear that links with the flywheel which is a gear connected to the crankshaft,\nThis turns the crankshaft which is connected through gears to the magnetos\nthese then start generating electricity to the spark plugs to ignite the fuel in the cylinders. \n\nImpulse Coupler - The Starter doesn't get enough RPMs to really get the mags going so an impulse coupler helps get the magneto spinning at first\nto generate enough electricity for the spark plugs.\n\nHow:\n\nWhy:\n",
           "title": "Constant Speed Governor",
           "type": "label"
         },
@@ -5045,7 +5045,7 @@
               "y": 463
             }
           ],
-          "rawHtml": "<p><br></p>",
+          "rawHtml": "<h3>What</h3><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
           "rawText": "\n",
           "title": "Retractable Landing Gear",
           "type": "label"
@@ -5053,7 +5053,7 @@
         {
           "alts": {},
           "hidden": [],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "title": "Antennas",
           "type": "fill"
         },
@@ -5167,8 +5167,8 @@
               "y": 597
             }
           ],
-          "rawHtml": "<p>Tricycle Type, Steerable nose wheel and two main wheels.</p><p>Shock absorption provided by tubular spring steel main landing gear struts,</p><p>and air/oil oleo shock strut for the nose gear. </p><p>Oleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, </p><p>on landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.</p><p>The <span class=\"popup-word\">Shimmy Damper</span> - Prevents the nose wheel from vibrating excessively during higher ground speeds,</p><p>contains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.</p><p>Nose gear connected to the Rudders via spring loaded steering bungee.</p>",
-          "rawText": "Tricycle Type, Steerable nose wheel and two main wheels.\nShock absorption provided by tubular spring steel main landing gear struts,\nand air/oil oleo shock strut for the nose gear. \nOleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, \non landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.\nThe Torque Link - prevents the piston from rotating in the cylinder connected to both of them.\nShimmy Damper - Prevents the nose wheel from vibrating excessively during higher ground speeds,\ncontains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.\nNose gear connected to the Rudders via spring loaded steering bungee.\n",
+          "rawHtml": "<h3>What</h3><p>Tricycle Type, Steerable nose wheel and two main wheels.</p><p>Shock absorption provided by tubular spring steel main landing gear struts,</p><p>and air/oil oleo shock strut for the nose gear. </p><p>Oleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, </p><p>on landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.</p><p>The <span class=\"popup-word\">Shimmy Damper</span> - Prevents the nose wheel from vibrating excessively during higher ground speeds,</p><p>contains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.</p><p>Nose gear connected to the Rudders via spring loaded steering bungee.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTricycle Type, Steerable nose wheel and two main wheels.\nShock absorption provided by tubular spring steel main landing gear struts,\nand air/oil oleo shock strut for the nose gear. \nOleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, \non landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.\nThe Torque Link - prevents the piston from rotating in the cylinder connected to both of them.\nShimmy Damper - Prevents the nose wheel from vibrating excessively during higher ground speeds,\ncontains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.\nNose gear connected to the Rudders via spring loaded steering bungee.\n\nHow:\n\nWhy:\n",
           "title": "Fuel System",
           "type": "label"
         },
@@ -5318,8 +5318,8 @@
               "y": 36
             }
           ],
-          "rawHtml": "<p>Single disc, hydraulically actuated brake on each main gear wheel, </p><p>Each brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.</p><p>There are two <span class=\"popup-word\">master cylinders</span> one on each of the left seats brake pedals.</p><p>The Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.</p><p>Pushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines </p><p>into the break assembly which then pushes against another piston that clamps the break pads</p><p>against the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.</p><p><br></p><p>Hydraulic Fluid color is a light red</p><p>If the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.</p>",
-          "rawText": "Single disc, hydraulically actuated brake on each main gear wheel, \nEach brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.\nThere are two master cylinders one on each of the left seats brake pedals.\nThe Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.\nPushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines \ninto the break assembly which then pushes against another piston that clamps the break pads\nagainst the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.\n\nHydraulic Fluid color is a light red\nIf the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.\n",
+          "rawHtml": "<h3>What</h3><p>Single disc, hydraulically actuated brake on each main gear wheel, </p><p>Each brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.</p><p>There are two <span class=\"popup-word\">master cylinders</span> one on each of the left seats brake pedals.</p><p>The Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.</p><p>Pushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines </p><p>into the break assembly which then pushes against another piston that clamps the break pads</p><p>against the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.</p><p><br></p><p>Hydraulic Fluid color is a light red</p><p>If the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nSingle disc, hydraulically actuated brake on each main gear wheel, \nEach brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.\nThere are two master cylinders one on each of the left seats brake pedals.\nThe Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.\nPushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines \ninto the break assembly which then pushes against another piston that clamps the break pads\nagainst the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.\n\nHydraulic Fluid color is a light red\nIf the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.\n\nHow:\n\nWhy:\n",
           "title": "Electrical System",
           "type": "label"
         },
@@ -5347,8 +5347,8 @@
               "word": "Flaps"
             }
           ],
-          "rawHtml": "<p>Primary</p><p>Ailerons | Rudder | Elevator</p><p><br></p><p>Secondary</p><p>Flaps | Trim</p>",
-          "rawText": "Primary\nAilerons | Rudder | Elevator\n\nSecondary\nFlaps | Trim\n",
+          "rawHtml": "<h3>What</h3><p>Primary</p><p>Ailerons | Rudder | Elevator</p><p><br></p><p>Secondary</p><p>Flaps | Trim</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPrimary\nAilerons | Rudder | Elevator\n\nSecondary\nFlaps | Trim\n\nHow:\n\nWhy:\n",
           "title": "Primary / Secondary Controls",
           "type": "fill"
         },
@@ -5480,8 +5480,8 @@
               "word": "4"
             }
           ],
-          "rawHtml": "<p><strong>Acronym</strong> - LHAND12348</p><ul><li>Lycoming IO 360 L2A: Lycoming (Company) | Injected Opposed |  360 cubic inches of air displacement (total space inside cylinders) | L2A = Model number</li><li>Horizontally Opposed Cylinders</li><li>Air Cooled</li><li>Naturally Aspirated</li><li>Direct Drive</li><li>180 Horsepower</li><li>2 Magnetos</li><li>360 cubic inch air displacement</li><li>4 four stroke cylinders - intake, compression, power, exhaust</li><li>8 Spark Plugs</li></ul><p><br></p><p>Spark plugs ignite fuel/ air mixture in the cylinders causing a controlled explosion that pushes the pistons up and down,</p><p>these pistons are connected to the crankshaft rotating it which is directly connected to the propeller</p><p>so the prop rotates at the same speed as the crankshaft (Direct Drive).</p>",
-          "rawText": "Acronym - LHAND12348\nLycoming IO 360 L2A: Lycoming (Company) | Injected Opposed |  360 cubic inches of air displacement (total space inside cylinders) | L2A = Model number\nHorizontally Opposed Cylinders\nAir Cooled\nNaturally Aspirated\nDirect Drive\n180 Horsepower\n2 Magnetos\n360 cubic inch air displacement\n4 four stroke cylinders - intake, compression, power, exhaust\n8 Spark Plugs\n\nSpark plugs ignite fuel/ air mixture in the cylinders causing a controlled explosion that pushes the pistons up and down,\nthese pistons are connected to the crankshaft rotating it which is directly connected to the propeller\nso the prop rotates at the same speed as the crankshaft (Direct Drive).\n",
+          "rawHtml": "<h3>What</h3><p><strong>Acronym</strong> - LHAND12348</p><ul><li>Lycoming IO 360 L2A: Lycoming (Company) | Injected Opposed |  360 cubic inches of air displacement (total space inside cylinders) | L2A = Model number</li><li>Horizontally Opposed Cylinders</li><li>Air Cooled</li><li>Naturally Aspirated</li><li>Direct Drive</li><li>180 Horsepower</li><li>2 Magnetos</li><li>360 cubic inch air displacement</li><li>4 four stroke cylinders - intake, compression, power, exhaust</li><li>8 Spark Plugs</li></ul><p><br></p><p>Spark plugs ignite fuel/ air mixture in the cylinders causing a controlled explosion that pushes the pistons up and down,</p><p>these pistons are connected to the crankshaft rotating it which is directly connected to the propeller</p><p>so the prop rotates at the same speed as the crankshaft (Direct Drive).</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAcronym - LHAND12348\nLycoming IO 360 L2A: Lycoming (Company) | Injected Opposed |  360 cubic inches of air displacement (total space inside cylinders) | L2A = Model number\nHorizontally Opposed Cylinders\nAir Cooled\nNaturally Aspirated\nDirect Drive\n180 Horsepower\n2 Magnetos\n360 cubic inch air displacement\n4 four stroke cylinders - intake, compression, power, exhaust\n8 Spark Plugs\n\nSpark plugs ignite fuel/ air mixture in the cylinders causing a controlled explosion that pushes the pistons up and down,\nthese pistons are connected to the crankshaft rotating it which is directly connected to the propeller\nso the prop rotates at the same speed as the crankshaft (Direct Drive).\n\nHow:\n\nWhy:\n",
           "title": "Engine",
           "type": "fill"
         },
@@ -5529,8 +5529,8 @@
               "word": "copper"
             }
           ],
-          "rawHtml": "<p>We have two magnetos for redundancy and better fuel burn connected each to a spark plug in each cylinder for a total of 8.</p><p>Consists of a Magnet geared to the engine which causes it to spin next to copper wires which generates electricity for the spark plugs.</p><p>Spark Plug Fouling - Caused by too rich a mixture at lower RPMs or running the engine too cold.</p><p>Leads to carbon deposits that make the engine run rougher and can reduce RPMs, can be noticed in Mag tests sometimes with roughness and higher drops.</p><p>Need to run the engine hotter and burn off these deposits to fix the issue.</p><p>If a mag doesn't drop at all it could be not grounding (turning off) </p>",
-          "rawText": "We have two magnetos for redundancy and better fuel burn connected each to a spark plug in each cylinder for a total of 8.\nConsists of a Magnet geared to the engine which causes it to spin next to copper wires which generates electricity for the spark plugs.\nSpark Plug Fouling - Caused by too rich a mixture at lower RPMs or running the engine too cold.\nLeads to carbon deposits that make the engine run rougher and can reduce RPMs, can be noticed in Mag tests sometimes with roughness and higher drops.\nNeed to run the engine hotter and burn off these deposits to fix the issue.\nIf a mag doesn't drop at all it could be not grounding (turning off) \n",
+          "rawHtml": "<h3>What</h3><p>We have two magnetos for redundancy and better fuel burn connected each to a spark plug in each cylinder for a total of 8.</p><p>Consists of a Magnet geared to the engine which causes it to spin next to copper wires which generates electricity for the spark plugs.</p><p>Spark Plug Fouling - Caused by too rich a mixture at lower RPMs or running the engine too cold.</p><p>Leads to carbon deposits that make the engine run rougher and can reduce RPMs, can be noticed in Mag tests sometimes with roughness and higher drops.</p><p>Need to run the engine hotter and burn off these deposits to fix the issue.</p><p>If a mag doesn't drop at all it could be not grounding (turning off) </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWe have two magnetos for redundancy and better fuel burn connected each to a spark plug in each cylinder for a total of 8.\nConsists of a Magnet geared to the engine which causes it to spin next to copper wires which generates electricity for the spark plugs.\nSpark Plug Fouling - Caused by too rich a mixture at lower RPMs or running the engine too cold.\nLeads to carbon deposits that make the engine run rougher and can reduce RPMs, can be noticed in Mag tests sometimes with roughness and higher drops.\nNeed to run the engine hotter and burn off these deposits to fix the issue.\nIf a mag doesn't drop at all it could be not grounding (turning off) \n\nHow:\n\nWhy:\n",
           "title": "Magnetos",
           "type": "fill"
         },
@@ -5554,8 +5554,8 @@
               "word": "fins,"
             }
           ],
-          "rawHtml": "<p>Receives Ram air from the intake on the bottom of the front engine cowling covered by an air filter.</p><p>This goes through an air box, if the filter gets blocked the engine creates a suction opening a spring loaded alternate air door.</p><p>This brings unfiltered air in which can reduce power around 10%.</p><p>after the air box it goes into a fuel / air control unit and then ducted other the engine cylinders.</p><p>This is a naturally aspirated system which means the intake doesn't use a turbo or supercharger.</p><p><br></p><p>Also Air cooled from air flowing over the cooling fins, as opposed to something like liquid cooling.</p><p>Ways to cool an engine - Decrease throttle, increase airspeed, enrich mixture. Oil also cools the engine.</p>",
-          "rawText": "Receives Ram air from the intake on the bottom of the front engine cowling covered by an air filter.\nThis goes through an air box, if the filter gets blocked the engine creates a suction opening a spring loaded alternate air door.\nThis brings unfiltered air in which can reduce power around 10%.\nafter the air box it goes into a fuel / air control unit and then ducted other the engine cylinders.\nThis is a naturally aspirated system which means the intake doesn't use a turbo or supercharger.\n\nAlso Air cooled from air flowing over the cooling fins, as opposed to something like liquid cooling.\nWays to cool an engine - Decrease throttle, increase airspeed, enrich mixture. Oil also cools the engine.\n",
+          "rawHtml": "<h3>What</h3><p>Receives Ram air from the intake on the bottom of the front engine cowling covered by an air filter.</p><p>This goes through an air box, if the filter gets blocked the engine creates a suction opening a spring loaded alternate air door.</p><p>This brings unfiltered air in which can reduce power around 10%.</p><p>after the air box it goes into a fuel / air control unit and then ducted other the engine cylinders.</p><p>This is a naturally aspirated system which means the intake doesn't use a turbo or supercharger.</p><p><br></p><p>Also Air cooled from air flowing over the cooling fins, as opposed to something like liquid cooling.</p><p>Ways to cool an engine - Decrease throttle, increase airspeed, enrich mixture. Oil also cools the engine.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nReceives Ram air from the intake on the bottom of the front engine cowling covered by an air filter.\nThis goes through an air box, if the filter gets blocked the engine creates a suction opening a spring loaded alternate air door.\nThis brings unfiltered air in which can reduce power around 10%.\nafter the air box it goes into a fuel / air control unit and then ducted other the engine cylinders.\nThis is a naturally aspirated system which means the intake doesn't use a turbo or supercharger.\n\nAlso Air cooled from air flowing over the cooling fins, as opposed to something like liquid cooling.\nWays to cool an engine - Decrease throttle, increase airspeed, enrich mixture. Oil also cools the engine.\n\nHow:\n\nWhy:\n",
           "title": "Air Induction System",
           "type": "fill"
         },
@@ -5575,8 +5575,8 @@
               "word": "1"
             }
           ],
-          "rawHtml": "<p>Two Bladed Fixed pitch 76 inch propeller manufactured by McCauley. Made of aluminum alloy.</p><p>Can shave this blade down at most 1 inch.</p><p>The blade is twisted because the tip spins a lot faster traveling a longer distance in the same time.</p><p>It makes it generate uniform thrust along the propeller. </p><p>It is a middle pitch prop a combo of a climb and cruise, cruise ones have bigger angles to take bigger bites of air.</p>",
-          "rawText": "Two Bladed Fixed pitch 76 inch propeller manufactured by McCauley. Made of aluminum alloy.\nCan shave this blade down at most 1 inch.\nThe blade is twisted because the tip spins a lot faster traveling a longer distance in the same time.\nIt makes it generate uniform thrust along the propeller. \nIt is a middle pitch prop a combo of a climb and cruise, cruise ones have bigger angles to take bigger bites of air.\n",
+          "rawHtml": "<h3>What</h3><p>Two Bladed Fixed pitch 76 inch propeller manufactured by McCauley. Made of aluminum alloy.</p><p>Can shave this blade down at most 1 inch.</p><p>The blade is twisted because the tip spins a lot faster traveling a longer distance in the same time.</p><p>It makes it generate uniform thrust along the propeller. </p><p>It is a middle pitch prop a combo of a climb and cruise, cruise ones have bigger angles to take bigger bites of air.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTwo Bladed Fixed pitch 76 inch propeller manufactured by McCauley. Made of aluminum alloy.\nCan shave this blade down at most 1 inch.\nThe blade is twisted because the tip spins a lot faster traveling a longer distance in the same time.\nIt makes it generate uniform thrust along the propeller. \nIt is a middle pitch prop a combo of a climb and cruise, cruise ones have bigger angles to take bigger bites of air.\n\nHow:\n\nWhy:\n",
           "title": "Propeller",
           "type": "fill"
         },
@@ -5604,8 +5604,8 @@
               "word": "shock"
             }
           ],
-          "rawHtml": "<p>Tricycle Type, Steerable nose wheel and two main wheels.</p><p>Shock absorption provided by tubular spring steel main landing gear struts,</p><p>and air/oil oleo shock strut for the nose gear. </p><p>Oleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, </p><p>on landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.</p><p>The <span class=\"popup-word\">Shimmy Damper</span> - Prevents the nose wheel from vibrating excessively during higher ground speeds,</p><p>contains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.</p><p>Nose gear connected to the Rudders via spring loaded steering bungee.</p>",
-          "rawText": "Tricycle Type, Steerable nose wheel and two main wheels.\nShock absorption provided by tubular spring steel main landing gear struts,\nand air/oil oleo shock strut for the nose gear. \nOleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, \non landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.\nThe Torque Link - prevents the piston from rotating in the cylinder connected to both of them.\nShimmy Damper - Prevents the nose wheel from vibrating excessively during higher ground speeds,\ncontains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.\nNose gear connected to the Rudders via spring loaded steering bungee.\n",
+          "rawHtml": "<h3>What</h3><p>Tricycle Type, Steerable nose wheel and two main wheels.</p><p>Shock absorption provided by tubular spring steel main landing gear struts,</p><p>and air/oil oleo shock strut for the nose gear. </p><p>Oleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, </p><p>on landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.</p><p>The <span class=\"popup-word\">Shimmy Damper</span> - Prevents the nose wheel from vibrating excessively during higher ground speeds,</p><p>contains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.</p><p>Nose gear connected to the Rudders via spring loaded steering bungee.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTricycle Type, Steerable nose wheel and two main wheels.\nShock absorption provided by tubular spring steel main landing gear struts,\nand air/oil oleo shock strut for the nose gear. \nOleo Strut - The piston you can see connect to the nose gear has some sort of oil in it, \non landing this gets pushed up into a cylinder above it which contains compressed air or nitrogen that cushions the blow.\nThe Torque Link - prevents the piston from rotating in the cylinder connected to both of them.\nShimmy Damper - Prevents the nose wheel from vibrating excessively during higher ground speeds,\ncontains hydraulic fluid is limited on how fast it can move side to side so it resits movement at higher speeds.\nNose gear connected to the Rudders via spring loaded steering bungee.\n\nHow:\n\nWhy:\n",
           "title": "Landing Gear",
           "type": "fill"
         },
@@ -5637,8 +5637,8 @@
               "word": "red"
             }
           ],
-          "rawHtml": "<p>Single disc, hydraulically actuated brake on each main gear wheel, </p><p>Each brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.</p><p>There are two <span class=\"popup-word\">master cylinders</span> one on each of the left seats brake pedals.</p><p>The Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.</p><p>Pushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines </p><p>into the break assembly which then pushes against another piston that clamps the break pads</p><p>against the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.</p><p><br></p><p>Hydraulic Fluid color is a light red</p><p>If the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.</p>",
-          "rawText": "Single disc, hydraulically actuated brake on each main gear wheel, \nEach brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.\nThere are two master cylinders one on each of the left seats brake pedals.\nThe Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.\nPushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines \ninto the break assembly which then pushes against another piston that clamps the break pads\nagainst the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.\n\nHydraulic Fluid color is a light red\nIf the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.\n",
+          "rawHtml": "<h3>What</h3><p>Single disc, hydraulically actuated brake on each main gear wheel, </p><p>Each brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.</p><p>There are two <span class=\"popup-word\">master cylinders</span> one on each of the left seats brake pedals.</p><p>The Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.</p><p>Pushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines </p><p>into the break assembly which then pushes against another piston that clamps the break pads</p><p>against the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.</p><p><br></p><p>Hydraulic Fluid color is a light red</p><p>If the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nSingle disc, hydraulically actuated brake on each main gear wheel, \nEach brake is connected by a small hydraulic line going to a master cylinder connected to the brake pedals.\nThere are two master cylinders one on each of the left seats brake pedals.\nThe Right seat breaks are mechanically linked to the left seats and push down on the master cylinders as well.\nPushing on the break pushes down on the master cylinders which sends hydraulic fluid through the lines \ninto the break assembly which then pushes against another piston that clamps the break pads\nagainst the steel wheel disc that spin with the wheel, this creates friction slowing the rotation.\n\nHydraulic Fluid color is a light red\nIf the brakes feel spongy on landing you can try pumping them to build up pressure with the fluid.\n\nHow:\n\nWhy:\n",
           "title": "Break System",
           "type": "fill"
         },
@@ -5662,8 +5662,8 @@
               "word": "Contaminants"
             }
           ],
-          "rawHtml": "<p>Oil Serves multiple Purposes in the Engine</p><p>1: Lubrication of Engine parts</p><p>2: Cooling of the Engine</p><p>3: Carrying away Contaminants</p><p>4: Helps provide a seal between the cylinder walls and pistons.</p><p><br></p><p>We need a minimum of 5 Quarts (School Policy 6) and can hold at most 8. Closer to 8 you can spray or burn oil out but can be used for long flights.</p><p>We have a Wet oil sump on our engine opposed to a dry one. </p><p>a Wet system is more simply with pan at the bottom that collects oil as gravity pulls it down, it then goes through a strainer</p><p>to the engine driven oil pump then the oil cooler and filter then a pressure relief valve which sends some back if pressure is too high,</p><p>then through the engine and then gravity pulls it back down to the sump pan. </p><p>A Dry system has a separate oil tank and uses a series of pump to keep oil circulating, needed for aerobatic planes.</p><p>Adding oil is considered basic upkeep.</p>",
-          "rawText": "Oil Serves multiple Purposes in the Engine\n1: Lubrication of Engine parts\n2: Cooling of the Engine\n3: Carrying away Contaminants\n4: Helps provide a seal between the cylinder walls and pistons.\n\nWe need a minimum of 5 Quarts (School Policy 6) and can hold at most 8. Closer to 8 you can spray or burn oil out but can be used for long flights.\nWe have a Wet oil sump on our engine opposed to a dry one. \na Wet system is more simply with pan at the bottom that collects oil as gravity pulls it down, it then goes through a strainer\nto the engine driven oil pump then the oil cooler and filter then a pressure relief valve which sends some back if pressure is too high,\nthen through the engine and then gravity pulls it back down to the sump pan. \nA Dry system has a separate oil tank and uses a series of pump to keep oil circulating, needed for aerobatic planes.\nAdding oil is considered basic upkeep.\n",
+          "rawHtml": "<h3>What</h3><p>Oil Serves multiple Purposes in the Engine</p><p>1: Lubrication of Engine parts</p><p>2: Cooling of the Engine</p><p>3: Carrying away Contaminants</p><p>4: Helps provide a seal between the cylinder walls and pistons.</p><p><br></p><p>We need a minimum of 5 Quarts (School Policy 6) and can hold at most 8. Closer to 8 you can spray or burn oil out but can be used for long flights.</p><p>We have a Wet oil sump on our engine opposed to a dry one. </p><p>a Wet system is more simply with pan at the bottom that collects oil as gravity pulls it down, it then goes through a strainer</p><p>to the engine driven oil pump then the oil cooler and filter then a pressure relief valve which sends some back if pressure is too high,</p><p>then through the engine and then gravity pulls it back down to the sump pan. </p><p>A Dry system has a separate oil tank and uses a series of pump to keep oil circulating, needed for aerobatic planes.</p><p>Adding oil is considered basic upkeep.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nOil Serves multiple Purposes in the Engine\n1: Lubrication of Engine parts\n2: Cooling of the Engine\n3: Carrying away Contaminants\n4: Helps provide a seal between the cylinder walls and pistons.\n\nWe need a minimum of 5 Quarts (School Policy 6) and can hold at most 8. Closer to 8 you can spray or burn oil out but can be used for long flights.\nWe have a Wet oil sump on our engine opposed to a dry one. \na Wet system is more simply with pan at the bottom that collects oil as gravity pulls it down, it then goes through a strainer\nto the engine driven oil pump then the oil cooler and filter then a pressure relief valve which sends some back if pressure is too high,\nthen through the engine and then gravity pulls it back down to the sump pan. \nA Dry system has a separate oil tank and uses a series of pump to keep oil circulating, needed for aerobatic planes.\nAdding oil is considered basic upkeep.\n\nHow:\n\nWhy:\n",
           "title": "Oil System",
           "type": "fill"
         },
@@ -5679,16 +5679,16 @@
               "word": "70"
             }
           ],
-          "rawHtml": "<p><strong>Fuel Injection</strong> - No icing, better fuel flow, faster throttle response, better cold weather starts.</p><p>Difficult hot engine starts, can get vapor lock on the ground during hot days.</p><p><strong>Carburetor</strong> - Icing can occur anywhere between 20 and 70 degrees Fahrenheit.</p>",
-          "rawText": "Fuel Injection - No icing, better fuel flow, faster throttle response, better cold weather starts.\nDifficult hot engine starts, can get vapor lock on the ground during hot days.\nCarburetor - Icing can occur anywhere between 20 and 70 degrees Fahrenheit.\n",
+          "rawHtml": "<h3>What</h3><p><strong>Fuel Injection</strong> - No icing, better fuel flow, faster throttle response, better cold weather starts.</p><p>Difficult hot engine starts, can get vapor lock on the ground during hot days.</p><p><strong>Carburetor</strong> - Icing can occur anywhere between 20 and 70 degrees Fahrenheit.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nFuel Injection - No icing, better fuel flow, faster throttle response, better cold weather starts.\nDifficult hot engine starts, can get vapor lock on the ground during hot days.\nCarburetor - Icing can occur anywhere between 20 and 70 degrees Fahrenheit.\n\nHow:\n\nWhy:\n",
           "title": "Fuel Injection Vs Carburetor",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Uses 2 Vacuums driven by engine geared to the crankshaft that suck air from the cabin.</p><p>If the pump gets too low of air pressure there are L VAC and R VAC annunciators, one for each vacuum.</p><p>Powers the Attitude Indicator and Heading Indicator which both use rigidity in space.</p><p>Susceptible to tumbling during excessive pitches or banks.</p><p><br></p>",
-          "rawText": "Uses 2 Vacuums driven by engine geared to the crankshaft that suck air from the cabin.\nIf the pump gets too low of air pressure there are L VAC and R VAC annunciators, one for each vacuum.\nPowers the Attitude Indicator and Heading Indicator which both use rigidity in space.\nSusceptible to tumbling during excessive pitches or banks.\n\n",
+          "rawHtml": "<h3>What</h3><p>Uses 2 Vacuums driven by engine geared to the crankshaft that suck air from the cabin.</p><p>If the pump gets too low of air pressure there are L VAC and R VAC annunciators, one for each vacuum.</p><p>Powers the Attitude Indicator and Heading Indicator which both use rigidity in space.</p><p>Susceptible to tumbling during excessive pitches or banks.</p><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nUses 2 Vacuums driven by engine geared to the crankshaft that suck air from the cabin.\nIf the pump gets too low of air pressure there are L VAC and R VAC annunciators, one for each vacuum.\nPowers the Attitude Indicator and Heading Indicator which both use rigidity in space.\nSusceptible to tumbling during excessive pitches or banks.\n\nHow:\n\nWhy:\n",
           "title": "Vacuum System",
           "type": "fill"
         }
@@ -5701,8 +5701,8 @@
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Carbon Monoxide is odorless, tasteless, and colorless.</p><p>There is a heater shroud around the exhaust pipe to trap hot air around it and lead it to the cabin for heat.</p><p>If the exhaust pipe gets cracked carbon monoxide from the exhaust could leak into the cabin from the heating vents.</p><p>Carbon Monoxide poisoning occurs because Carbon Monoxide attaches to hemoglobin 200 times easier than oxygen so it takes its spot in the blood.</p><p>Symptoms can be headaches, blurred vision, drowsiness, loss of muscle power.</p><p>Mitigated by turning heaters off, opening vents and windows, supplemental oxygen.</p><p>Compared to other hypoxias this one you usually don't feel euphoric just crappy.</p>",
-          "rawText": "Carbon Monoxide is odorless, tasteless, and colorless.\nThere is a heater shroud around the exhaust pipe to trap hot air around it and lead it to the cabin for heat.\nIf the exhaust pipe gets cracked carbon monoxide from the exhaust could leak into the cabin from the heating vents.\nCarbon Monoxide poisoning occurs because Carbon Monoxide attaches to hemoglobin 200 times easier than oxygen so it takes its spot in the blood.\nSymptoms can be headaches, blurred vision, drowsiness, loss of muscle power.\nMitigated by turning heaters off, opening vents and windows, supplemental oxygen.\nCompared to other hypoxias this one you usually don't feel euphoric just crappy.\n",
+          "rawHtml": "<h3>What</h3><p>Carbon Monoxide is odorless, tasteless, and colorless.</p><p>There is a heater shroud around the exhaust pipe to trap hot air around it and lead it to the cabin for heat.</p><p>If the exhaust pipe gets cracked carbon monoxide from the exhaust could leak into the cabin from the heating vents.</p><p>Carbon Monoxide poisoning occurs because Carbon Monoxide attaches to hemoglobin 200 times easier than oxygen so it takes its spot in the blood.</p><p>Symptoms can be headaches, blurred vision, drowsiness, loss of muscle power.</p><p>Mitigated by turning heaters off, opening vents and windows, supplemental oxygen.</p><p>Compared to other hypoxias this one you usually don't feel euphoric just crappy.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCarbon Monoxide is odorless, tasteless, and colorless.\nThere is a heater shroud around the exhaust pipe to trap hot air around it and lead it to the cabin for heat.\nIf the exhaust pipe gets cracked carbon monoxide from the exhaust could leak into the cabin from the heating vents.\nCarbon Monoxide poisoning occurs because Carbon Monoxide attaches to hemoglobin 200 times easier than oxygen so it takes its spot in the blood.\nSymptoms can be headaches, blurred vision, drowsiness, loss of muscle power.\nMitigated by turning heaters off, opening vents and windows, supplemental oxygen.\nCompared to other hypoxias this one you usually don't feel euphoric just crappy.\n\nHow:\n\nWhy:\n",
           "title": "Carbon Monoxide",
           "type": "fill"
         },
@@ -5766,8 +5766,8 @@
               "word": "drugs."
             }
           ],
-          "rawHtml": "<p>Hypoxic - Caused by insufficient oxygen being available to the body. Stems from operating at high altitudes without supplemental oxygen, starts around 10000ft</p><p><br></p><p>Hypemic - When Hemoglobin isn't able to transport enough oxygen to the cells, Stems from Carbon Monoxide poisoning or blood donations.</p><p><br></p><p>Stagnant - Oxygen rich blood can't move around sufficiently, Stems from High G forces, extreme cold, limb going to sleep, heart attack.</p><p><br></p><p>Histotoxic - The inability of cells to be able to use oxygen because they are poison by alcohol or drugs. </p><p><br></p><p>Symptoms: Euphoria | Headaches | Impaired judgment | Blue fingertips | Tingling | Vision Worsens</p><p>It effects each person differently but if you suspect somebody has it provide supplemental oxygen declare emergency and descend.</p><p>FAA recommend using supplemental oxygen at 10000 ft during the day and 5000 at night.</p>",
-          "rawText": "Hypoxic - Caused by insufficient oxygen being available to the body. Stems from operating at high altitudes without supplemental oxygen, starts around 10000ft\n\nHypemic - When Hemoglobin isn't able to transport enough oxygen to the cells, Stems from Carbon Monoxide poisoning or blood donations.\n\nStagnant - Oxygen rich blood can't move around sufficiently, Stems from High G forces, extreme cold, limb going to sleep, heart attack.\n\nHistotoxic - The inability of cells to be able to use oxygen because they are poison by alcohol or drugs. \n\nSymptoms: Euphoria | Headaches | Impaired judgment | Blue fingertips | Tingling | Vision Worsens\nIt effects each person differently but if you suspect somebody has it provide supplemental oxygen declare emergency and descend.\nFAA recommend using supplemental oxygen at 10000 ft during the day and 5000 at night.\n",
+          "rawHtml": "<h3>What</h3><p>Hypoxic - Caused by insufficient oxygen being available to the body. Stems from operating at high altitudes without supplemental oxygen, starts around 10000ft</p><p><br></p><p>Hypemic - When Hemoglobin isn't able to transport enough oxygen to the cells, Stems from Carbon Monoxide poisoning or blood donations.</p><p><br></p><p>Stagnant - Oxygen rich blood can't move around sufficiently, Stems from High G forces, extreme cold, limb going to sleep, heart attack.</p><p><br></p><p>Histotoxic - The inability of cells to be able to use oxygen because they are poison by alcohol or drugs. </p><p><br></p><p>Symptoms: Euphoria | Headaches | Impaired judgment | Blue fingertips | Tingling | Vision Worsens</p><p>It effects each person differently but if you suspect somebody has it provide supplemental oxygen declare emergency and descend.</p><p>FAA recommend using supplemental oxygen at 10000 ft during the day and 5000 at night.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nHypoxic - Caused by insufficient oxygen being available to the body. Stems from operating at high altitudes without supplemental oxygen, starts around 10000ft\n\nHypemic - When Hemoglobin isn't able to transport enough oxygen to the cells, Stems from Carbon Monoxide poisoning or blood donations.\n\nStagnant - Oxygen rich blood can't move around sufficiently, Stems from High G forces, extreme cold, limb going to sleep, heart attack.\n\nHistotoxic - The inability of cells to be able to use oxygen because they are poison by alcohol or drugs. \n\nSymptoms: Euphoria | Headaches | Impaired judgment | Blue fingertips | Tingling | Vision Worsens\nIt effects each person differently but if you suspect somebody has it provide supplemental oxygen declare emergency and descend.\nFAA recommend using supplemental oxygen at 10000 ft during the day and 5000 at night.\n\nHow:\n\nWhy:\n",
           "title": "Types of Hypoxia",
           "type": "fill"
         },
@@ -5803,8 +5803,8 @@
               "word": "unconsciousness"
             }
           ],
-          "rawHtml": "<p>Caused by heavy breathing that leads to insufficient carbon dioxide in the blood.</p><p>Counteracted by slowing breathing or breathing into a paper bag to recirculate that Carbon Dioxide.</p><p>Symptoms: Lightheaded or dizzy | tingling | visual impairment | At worst unconsciousness </p><p>If it is a passenger experiencing it its not a huge deal if they pass out it will slow their breathing.</p><p>If you don't know whether its hyperventilating or hypoxia treat it as hypoxia.</p>",
-          "rawText": "Caused by heavy breathing that leads to insufficient carbon dioxide in the blood.\nCounteracted by slowing breathing or breathing into a paper bag to recirculate that Carbon Dioxide.\nSymptoms: Lightheaded or dizzy | tingling | visual impairment | At worst unconsciousness \nIf it is a passenger experiencing it its not a huge deal if they pass out it will slow their breathing.\nIf you don't know whether its hyperventilating or hypoxia treat it as hypoxia.\n",
+          "rawHtml": "<h3>What</h3><p>Caused by heavy breathing that leads to insufficient carbon dioxide in the blood.</p><p>Counteracted by slowing breathing or breathing into a paper bag to recirculate that Carbon Dioxide.</p><p>Symptoms: Lightheaded or dizzy | tingling | visual impairment | At worst unconsciousness </p><p>If it is a passenger experiencing it its not a huge deal if they pass out it will slow their breathing.</p><p>If you don't know whether its hyperventilating or hypoxia treat it as hypoxia.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nCaused by heavy breathing that leads to insufficient carbon dioxide in the blood.\nCounteracted by slowing breathing or breathing into a paper bag to recirculate that Carbon Dioxide.\nSymptoms: Lightheaded or dizzy | tingling | visual impairment | At worst unconsciousness \nIf it is a passenger experiencing it its not a huge deal if they pass out it will slow their breathing.\nIf you don't know whether its hyperventilating or hypoxia treat it as hypoxia.\n\nHow:\n\nWhy:\n",
           "title": "Hyperventilation",
           "type": "fill"
         },
@@ -5824,16 +5824,16 @@
               "word": "nasal"
             }
           ],
-          "rawHtml": "<p>You should not fly while congested</p><p>It can lead to mucus blocks in the Eustachian tube that allows pressure to equalize in and out of the ear.</p><p>This can create a vacuum effect on descents that can cause severe ear pain, or a rupture.</p><p>Can be mitigated by pinching the nose and blowing, swallowing, chewing gum, and yawning. </p><p>Flying while congested can also lead to a sinus block in the nasal passages.</p><p>These can lead to excruciating pain, bloody mucus, teeth pain and occur on descents also.</p><p>These can both be mitigated in flight by descending slowly.</p>",
-          "rawText": "You should not fly while congested\nIt can lead to mucus blocks in the Eustachian tube that allows pressure to equalize in and out of the ear.\nThis can create a vacuum effect on descents that can cause severe ear pain, or a rupture.\nCan be mitigated by pinching the nose and blowing, swallowing, chewing gum, and yawning. \nFlying while congested can also lead to a sinus block in the nasal passages.\nThese can lead to excruciating pain, bloody mucus, teeth pain and occur on descents also.\nThese can both be mitigated in flight by descending slowly.\n",
+          "rawHtml": "<h3>What</h3><p>You should not fly while congested</p><p>It can lead to mucus blocks in the Eustachian tube that allows pressure to equalize in and out of the ear.</p><p>This can create a vacuum effect on descents that can cause severe ear pain, or a rupture.</p><p>Can be mitigated by pinching the nose and blowing, swallowing, chewing gum, and yawning. </p><p>Flying while congested can also lead to a sinus block in the nasal passages.</p><p>These can lead to excruciating pain, bloody mucus, teeth pain and occur on descents also.</p><p>These can both be mitigated in flight by descending slowly.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYou should not fly while congested\nIt can lead to mucus blocks in the Eustachian tube that allows pressure to equalize in and out of the ear.\nThis can create a vacuum effect on descents that can cause severe ear pain, or a rupture.\nCan be mitigated by pinching the nose and blowing, swallowing, chewing gum, and yawning. \nFlying while congested can also lead to a sinus block in the nasal passages.\nThese can lead to excruciating pain, bloody mucus, teeth pain and occur on descents also.\nThese can both be mitigated in flight by descending slowly.\n\nHow:\n\nWhy:\n",
           "title": "Inner Ear / Sinus",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>A lack of orientation with regard to the position, attitude, or movement of the aircraft.</p><p>We use three sensory systems to ascertain our orientation.</p><p>Visual: Eyes - Most important, loss of visual cues typically leads to disorientation </p><p>Somatosensory: Nerves in the skin and muscles that use gravity and feeling.</p><p>Vestibular: Inner ear organs (semicircular canals) that use balance to sense position.</p>",
-          "rawText": "A lack of orientation with regard to the position, attitude, or movement of the aircraft.\nWe use three sensory systems to ascertain our orientation.\nVisual: Eyes - Most important, loss of visual cues typically leads to disorientation \nSomatosensory: Nerves in the skin and muscles that use gravity and feeling.\nVestibular: Inner ear organs (semicircular canals) that use balance to sense position.\n",
+          "rawHtml": "<h3>What</h3><p>A lack of orientation with regard to the position, attitude, or movement of the aircraft.</p><p>We use three sensory systems to ascertain our orientation.</p><p>Visual: Eyes - Most important, loss of visual cues typically leads to disorientation </p><p>Somatosensory: Nerves in the skin and muscles that use gravity and feeling.</p><p>Vestibular: Inner ear organs (semicircular canals) that use balance to sense position.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nA lack of orientation with regard to the position, attitude, or movement of the aircraft.\nWe use three sensory systems to ascertain our orientation.\nVisual: Eyes - Most important, loss of visual cues typically leads to disorientation \nSomatosensory: Nerves in the skin and muscles that use gravity and feeling.\nVestibular: Inner ear organs (semicircular canals) that use balance to sense position.\n\nHow:\n\nWhy:\n",
           "title": "Spatial Disorientation",
           "type": "fill"
         },
@@ -5909,8 +5909,8 @@
               "word": "higher"
             }
           ],
-          "rawHtml": "<p>Acronym - ICEFLAGS</p><ul><li>Inversion: Abruptly going from climb to straight and level feeling like you are tumbling backwards / pitching up.</li><li>Coriolis: In a turn when you make an abrupt head movement creating a false sensation of a turn.</li><li>Elevator: Updrafts / Downdrafts make you feel like you are climbing or descending.</li><li>False Horizon: Lights or clouds can look like the horizon</li><li>Leans: Entering a bank slowly can be unnoticeable to the fluid in ears so when you level out it feels like a turn in the opposite direction.</li><li>Autokinesis: Flashing lights can appear to be moving when you stare at them or non flashing ones can appear to be flashing.</li><li>Graveyard Spiral: A prolonged constant rate turn can give the illusion you stopped turning you level out and think you are tuning in the opposite direction.</li><li>Somatogravic: Rapid decelerations or accelerations feels like pitching down or pitching up.</li></ul><p><br></p><p>Visual Illusions</p><ul><li>Runway Width Illusion - A narrower runway can make it look like you are higher than you are.</li></ul><p>\tA Wider runway can make it seem like you are lower.</p><ul><li><span class=\"popup-word\">Sloping Runways</span> - An upsloping runway makes it so you can see more of it like you would higher up so you think you are higher than you are.</li></ul><p>\tA downsloping runway shows you less so you think you are lower than you are.</p><p>\tA Narrow Upsloping runway could make you think you are much higher than you actually are and you could run into the terrain.</p><p>*Featureless Terrain or rain/ haze can make you think you are higher than you actually are also.</p>",
-          "rawText": "Acronym - ICEFLAGS\nInversion: Abruptly going from climb to straight and level feeling like you are tumbling backwards / pitching up.\nCoriolis: In a turn when you make an abrupt head movement creating a false sensation of a turn.\nElevator: Updrafts / Downdrafts make you feel like you are climbing or descending.\nFalse Horizon: Lights or clouds can look like the horizon\nLeans: Entering a bank slowly can be unnoticeable to the fluid in ears so when you level out it feels like a turn in the opposite direction.\nAutokinesis: Flashing lights can appear to be moving when you stare at them or non flashing ones can appear to be flashing.\nGraveyard Spiral: A prolonged constant rate turn can give the illusion you stopped turning you level out and think you are tuning in the opposite direction.\nSomatogravic: Rapid decelerations or accelerations feels like pitching down or pitching up.\n\nVisual Illusions\nRunway Width Illusion - A narrower runway can make it look like you are higher than you are.\n\tA Wider runway can make it seem like you are lower.\nSloping Runways - An upsloping runway makes it so you can see more of it like you would higher up so you think you are higher than you are.\n\tA downsloping runway shows you less so you think you are lower than you are.\n\tA Narrow Upsloping runway could make you think you are much higher than you actually are and you could run into the terrain.\n*Featureless Terrain or rain/ haze can make you think you are higher than you actually are also.\n",
+          "rawHtml": "<h3>What</h3><p>Acronym - ICEFLAGS</p><ul><li>Inversion: Abruptly going from climb to straight and level feeling like you are tumbling backwards / pitching up.</li><li>Coriolis: In a turn when you make an abrupt head movement creating a false sensation of a turn.</li><li>Elevator: Updrafts / Downdrafts make you feel like you are climbing or descending.</li><li>False Horizon: Lights or clouds can look like the horizon</li><li>Leans: Entering a bank slowly can be unnoticeable to the fluid in ears so when you level out it feels like a turn in the opposite direction.</li><li>Autokinesis: Flashing lights can appear to be moving when you stare at them or non flashing ones can appear to be flashing.</li><li>Graveyard Spiral: A prolonged constant rate turn can give the illusion you stopped turning you level out and think you are tuning in the opposite direction.</li><li>Somatogravic: Rapid decelerations or accelerations feels like pitching down or pitching up.</li></ul><p><br></p><p>Visual Illusions</p><ul><li>Runway Width Illusion - A narrower runway can make it look like you are higher than you are.</li></ul><p>\tA Wider runway can make it seem like you are lower.</p><ul><li><span class=\"popup-word\">Sloping Runways</span> - An upsloping runway makes it so you can see more of it like you would higher up so you think you are higher than you are.</li></ul><p>\tA downsloping runway shows you less so you think you are lower than you are.</p><p>\tA Narrow Upsloping runway could make you think you are much higher than you actually are and you could run into the terrain.</p><p>*Featureless Terrain or rain/ haze can make you think you are higher than you actually are also.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAcronym - ICEFLAGS\nInversion: Abruptly going from climb to straight and level feeling like you are tumbling backwards / pitching up.\nCoriolis: In a turn when you make an abrupt head movement creating a false sensation of a turn.\nElevator: Updrafts / Downdrafts make you feel like you are climbing or descending.\nFalse Horizon: Lights or clouds can look like the horizon\nLeans: Entering a bank slowly can be unnoticeable to the fluid in ears so when you level out it feels like a turn in the opposite direction.\nAutokinesis: Flashing lights can appear to be moving when you stare at them or non flashing ones can appear to be flashing.\nGraveyard Spiral: A prolonged constant rate turn can give the illusion you stopped turning you level out and think you are tuning in the opposite direction.\nSomatogravic: Rapid decelerations or accelerations feels like pitching down or pitching up.\n\nVisual Illusions\nRunway Width Illusion - A narrower runway can make it look like you are higher than you are.\n\tA Wider runway can make it seem like you are lower.\nSloping Runways - An upsloping runway makes it so you can see more of it like you would higher up so you think you are higher than you are.\n\tA downsloping runway shows you less so you think you are lower than you are.\n\tA Narrow Upsloping runway could make you think you are much higher than you actually are and you could run into the terrain.\n*Featureless Terrain or rain/ haze can make you think you are higher than you actually are also.\n\nHow:\n\nWhy:\n",
           "title": "Illusions",
           "type": "fill"
         },
@@ -5994,8 +5994,8 @@
               "word": "Pilot"
             }
           ],
-          "rawHtml": "<p>PAVE</p><p>Pilot</p><p>Aircraft</p><p>Environment</p><p>Emotion</p><p><br></p><p>IMSAFE</p><p>Illness</p><p>Medication - Best way to verify if allowed is to contact your AME.</p><p>Stress - There is short term acute stress which is normal and then long term Chronic stress which is bad.</p><p>Alcohol - 8 hours, &lt; .04 %, or simply under the influence (Hungover). Alcohol effects are worse at altitude.</p><p>Fatigue</p><p>Eating / Drinking</p>",
-          "rawText": "PAVE\nPilot\nAircraft\nEnvironment\nEmotion\n\nIMSAFE\nIllness\nMedication - Best way to verify if allowed is to contact your AME.\nStress - There is short term acute stress which is normal and then long term Chronic stress which is bad.\nAlcohol - 8 hours, < .04 %, or simply under the influence (Hungover). Alcohol effects are worse at altitude.\nFatigue\nEating / Drinking\n",
+          "rawHtml": "<h3>What</h3><p>PAVE</p><p>Pilot</p><p>Aircraft</p><p>Environment</p><p>Emotion</p><p><br></p><p>IMSAFE</p><p>Illness</p><p>Medication - Best way to verify if allowed is to contact your AME.</p><p>Stress - There is short term acute stress which is normal and then long term Chronic stress which is bad.</p><p>Alcohol - 8 hours, &lt; .04 %, or simply under the influence (Hungover). Alcohol effects are worse at altitude.</p><p>Fatigue</p><p>Eating / Drinking</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPAVE\nPilot\nAircraft\nEnvironment\nEmotion\n\nIMSAFE\nIllness\nMedication - Best way to verify if allowed is to contact your AME.\nStress - There is short term acute stress which is normal and then long term Chronic stress which is bad.\nAlcohol - 8 hours, < .04 %, or simply under the influence (Hungover). Alcohol effects are worse at altitude.\nFatigue\nEating / Drinking\n\nHow:\n\nWhy:\n",
           "title": "PAVE / IMSAFE",
           "type": "fill"
         },
@@ -6015,8 +6015,8 @@
               "word": "nitrogen"
             }
           ],
-          "rawHtml": "<p>You should not fly within 24 hours of going scuba diving if controlled ascents are necessary.</p><p>Else should wait at least 12 hours.</p><p>Increased pressure under water causing nitrogen to dissolve in your tissues</p><p>At altitude with lower pressure this nitrogen tries to bubble and escape in joints and other areas causing extreme pain,</p><p>this is called the bends.</p>",
-          "rawText": "You should not fly within 24 hours of going scuba diving if controlled ascents are necessary.\\nElse should wait at least 12 hours.\\nIncreased pressure under water causing nitrogen to dissolve in your tissues\\nAt altitude with lower pressure this nitrogen tries to bubble and escape in joints and other areas causing extreme pain,\\nthis is called the bends.\\n",
+          "rawHtml": "<h3>What</h3><p>You should not fly within 24 hours of going scuba diving if controlled ascents are necessary.</p><p>Else should wait at least 12 hours.</p><p>Increased pressure under water causing nitrogen to dissolve in your tissues</p><p>At altitude with lower pressure this nitrogen tries to bubble and escape in joints and other areas causing extreme pain,</p><p>this is called the bends.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nYou should not fly within 24 hours of going scuba diving if controlled ascents are necessary.\\nElse should wait at least 12 hours.\\nIncreased pressure under water causing nitrogen to dissolve in your tissues\\nAt altitude with lower pressure this nitrogen tries to bubble and escape in joints and other areas causing extreme pain,\\nthis is called the bends.\\n\n\nHow:\n\nWhy:\n",
           "title": "The Bends",
           "type": "fill"
         },
@@ -6060,8 +6060,8 @@
               "word": "antidote."
             }
           ],
-          "rawHtml": "<p>Neutralizing: Recognize the hazardous thought, label it as hazardous, say the antidote.</p><p>Anti Authority: Don't tell me what to do | Follow the rules they are usually right</p><p>Impulsivity: Do it quickly | Not so fast, think first</p><p>Invulnerability: It won't happen to me | Taking chances is foolish</p><p>Macho: I can do it | Taking chances is foolish</p><p>Resignation: What's the use? | I can make a difference</p>",
-          "rawText": "Neutralizing: Recognize the hazardous thought, label it as hazardous, say the antidote.\nAnti Authority: Don't tell me what to do | Follow the rules they are usually right\nImpulsivity: Do it quickly | Not so fast, think first\nInvulnerability: It won't happen to me | Taking chances is foolish\nMacho: I can do it | Taking chances is foolish\nResignation: What's the use? | I can make a difference\n",
+          "rawHtml": "<h3>What</h3><p>Neutralizing: Recognize the hazardous thought, label it as hazardous, say the antidote.</p><p>Anti Authority: Don't tell me what to do | Follow the rules they are usually right</p><p>Impulsivity: Do it quickly | Not so fast, think first</p><p>Invulnerability: It won't happen to me | Taking chances is foolish</p><p>Macho: I can do it | Taking chances is foolish</p><p>Resignation: What's the use? | I can make a difference</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nNeutralizing: Recognize the hazardous thought, label it as hazardous, say the antidote.\nAnti Authority: Don't tell me what to do | Follow the rules they are usually right\nImpulsivity: Do it quickly | Not so fast, think first\nInvulnerability: It won't happen to me | Taking chances is foolish\nMacho: I can do it | Taking chances is foolish\nResignation: What's the use? | I can make a difference\n\nHow:\n\nWhy:\n",
           "title": "Hazardous Attitudes",
           "type": "fill"
         },
@@ -6073,8 +6073,8 @@
               "word": "830.5"
             }
           ],
-          "rawHtml": "<p>FAR - 830.5</p><p>Have to report accidents or serious incidents immediately to nearest NTSB office, then a written report within 10 days.</p><p>Accident - Death or serious injury (Hospitalization more than 48 hours within 7 days) to person</p><p> or substantial damage (Requiring major repair or replacement of component) to aircraft.</p>",
-          "rawText": "FAR - 830.5\\nHave to report accidents or serious incidents immediately to nearest NTSB office, then a written report within 10 days.\\nAccident - Death or serious injury (Hospitalization more than 48 hours within 7 days) to person\\n or substantial damage (Requiring major repair or replacement of component) to aircraft.\\n",
+          "rawHtml": "<h3>What</h3><p>FAR - 830.5</p><p>Have to report accidents or serious incidents immediately to nearest NTSB office, then a written report within 10 days.</p><p>Accident - Death or serious injury (Hospitalization more than 48 hours within 7 days) to person</p><p> or substantial damage (Requiring major repair or replacement of component) to aircraft.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nFAR - 830.5\\nHave to report accidents or serious incidents immediately to nearest NTSB office, then a written report within 10 days.\\nAccident - Death or serious injury (Hospitalization more than 48 hours within 7 days) to person\\n or substantial damage (Requiring major repair or replacement of component) to aircraft.\\n\n\nHow:\n\nWhy:\n",
           "title": "Incidents / Accidents",
           "type": "fill"
         },
@@ -6118,8 +6118,8 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p><strong>Visual</strong> (Eyes) - Most helpful</p><p><em>Contains -</em></p><ul><li>Center Cones that work best with high light and provide color</li><li>Rim Rods responsible for peripheral vision and work best at night.</li></ul><p><strong>Vestibular</strong> (Inner Ear)</p><p>Contains </p><ul><li>Otolith Organs (Crystals)</li><li>Semicircular Canals (Fluid)</li></ul><p><strong>Kinesthetic</strong> (Muscles, Skin)</p><p>Uses receptors in muscle and skin to sense position.</p>",
-          "rawText": "Visual (Eyes) - Most helpful\nContains -\nCenter Cones that work best with high light and provide color\nRim Rods responsible for peripheral vision and work best at night.\nVestibular (Inner Ear)\nContains \nOtolith Organs (Crystals)\nSemicircular Canals (Fluid)\nKinesthetic (Muscles, Skin)\nUses receptors in muscle and skin to sense position.\n",
+          "rawHtml": "<h3>What</h3><p><strong>Visual</strong> (Eyes) - Most helpful</p><p><em>Contains -</em></p><ul><li>Center Cones that work best with high light and provide color</li><li>Rim Rods responsible for peripheral vision and work best at night.</li></ul><p><strong>Vestibular</strong> (Inner Ear)</p><p>Contains </p><ul><li>Otolith Organs (Crystals)</li><li>Semicircular Canals (Fluid)</li></ul><p><strong>Kinesthetic</strong> (Muscles, Skin)</p><p>Uses receptors in muscle and skin to sense position.</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nVisual (Eyes) - Most helpful\nContains -\nCenter Cones that work best with high light and provide color\nRim Rods responsible for peripheral vision and work best at night.\nVestibular (Inner Ear)\nContains \nOtolith Organs (Crystals)\nSemicircular Canals (Fluid)\nKinesthetic (Muscles, Skin)\nUses receptors in muscle and skin to sense position.\n\nHow:\n\nWhy:\n",
           "title": "The Three Sensory Systems",
           "type": "fill"
         }
@@ -6165,8 +6165,8 @@
               "word": "Horn"
             }
           ],
-          "rawHtml": "<p>Simulates Takeoff / Go-Around Configuration</p><p>Power 1500 RPM </p><p>Hold altitude until 60 - 65 kts - some do 55 but then stall happens almost instantly</p><p>Then go Full Power and Pitch for 25 degrees</p><p>Hold until Stall occurs - Call Out Stall Horn</p><p>Recover</p>",
-          "rawText": "Simulates Takeoff / Go-Around Configuration\nPower 1500 RPM \nHold altitude until 60 - 65 kts - some do 55 but then stall happens almost instantly\nThen go Full Power and Pitch for 25 degrees\nHold until Stall occurs - Call Out Stall Horn\nRecover\n",
+          "rawHtml": "<h3>What</h3><p>Simulates Takeoff / Go-Around Configuration</p><p>Power 1500 RPM </p><p>Hold altitude until 60 - 65 kts - some do 55 but then stall happens almost instantly</p><p>Then go Full Power and Pitch for 25 degrees</p><p>Hold until Stall occurs - Call Out Stall Horn</p><p>Recover</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nSimulates Takeoff / Go-Around Configuration\nPower 1500 RPM \nHold altitude until 60 - 65 kts - some do 55 but then stall happens almost instantly\nThen go Full Power and Pitch for 25 degrees\nHold until Stall occurs - Call Out Stall Horn\nRecover\n\nHow:\n\nWhy:\n",
           "title": "Power On Stall",
           "type": "fill"
         },
@@ -6234,8 +6234,8 @@
               "word": "Horn"
             }
           ],
-          "rawHtml": "<p>Power Off Stall - Simulates Landing Configuration Stall</p><p>Power 1800 RPM</p><p>Below 110 Kts - Flaps 10</p><p>Below 85 Kts - Flaps 20</p><p>Flaps 30</p><p>Pitch for 65 kts with a stabilized descent</p><p>Then power idle and pitch up to around 5 degrees </p><p>Hold until Stall occurs - Call Out Stall Horn</p><p>Recover</p>",
-          "rawText": "Power Off Stall - Simulates Landing Configuration Stall\nPower 1800 RPM\nBelow 110 Kts - Flaps 10\nBelow 85 Kts - Flaps 20\nFlaps 30\nPitch for 65 kts with a stabilized descent\nThen power idle and pitch up to around 5 degrees \nHold until Stall occurs - Call Out Stall Horn\nRecover\n",
+          "rawHtml": "<h3>What</h3><p>Power Off Stall - Simulates Landing Configuration Stall</p><p>Power 1800 RPM</p><p>Below 110 Kts - Flaps 10</p><p>Below 85 Kts - Flaps 20</p><p>Flaps 30</p><p>Pitch for 65 kts with a stabilized descent</p><p>Then power idle and pitch up to around 5 degrees </p><p>Hold until Stall occurs - Call Out Stall Horn</p><p>Recover</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPower Off Stall - Simulates Landing Configuration Stall\nPower 1800 RPM\nBelow 110 Kts - Flaps 10\nBelow 85 Kts - Flaps 20\nFlaps 30\nPitch for 65 kts with a stabilized descent\nThen power idle and pitch up to around 5 degrees \nHold until Stall occurs - Call Out Stall Horn\nRecover\n\nHow:\n\nWhy:\n",
           "title": "Power Off Stall",
           "type": "fill"
         },
@@ -6302,8 +6302,8 @@
               "word": "Full"
             }
           ],
-          "rawHtml": "<p>What: A max performance climb with 180 turn</p><p><br></p><p>Clean configuration</p><p>1500 ft AGL</p><p>105 knots - around 2300 RPM</p><p>Bug heading - you get +- 10 degrees </p><p>First 90 Degrees</p><p>Full power - stay level </p><p>30 degrees bank quickly</p><p>Then Slowly increase pitch to 15 degrees right at 90 degrees</p><p>Second 90 Degrees</p><p>Hold nose at 15 degrees - Requires more back pressure </p><p>Slowly bring bank to 0 right at 180 degrees</p><p>*Airspeed should end around 60 knots - stall speed is 48 clean - stall horn happens around 10 knots above that </p>",
-          "rawText": "What: A max performance climb with 180 turn\n\nClean configuration\n1500 ft AGL\n105 knots - around 2300 RPM\nBug heading - you get +- 10 degrees \nFirst 90 Degrees\nFull power - stay level \n30 degrees bank quickly\nThen Slowly increase pitch to 15 degrees right at 90 degrees\nSecond 90 Degrees\nHold nose at 15 degrees - Requires more back pressure \nSlowly bring bank to 0 right at 180 degrees\n*Airspeed should end around 60 knots - stall speed is 48 clean - stall horn happens around 10 knots above that \n",
+          "rawHtml": "<h3>What</h3><p>What: A max performance climb with 180 turn</p><p><br></p><p>Clean configuration</p><p>1500 ft AGL</p><p>105 knots - around 2300 RPM</p><p>Bug heading - you get +- 10 degrees </p><p>First 90 Degrees</p><p>Full power - stay level </p><p>30 degrees bank quickly</p><p>Then Slowly increase pitch to 15 degrees right at 90 degrees</p><p>Second 90 Degrees</p><p>Hold nose at 15 degrees - Requires more back pressure </p><p>Slowly bring bank to 0 right at 180 degrees</p><p>*Airspeed should end around 60 knots - stall speed is 48 clean - stall horn happens around 10 knots above that </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWhat: A max performance climb with 180 turn\n\nClean configuration\n1500 ft AGL\n105 knots - around 2300 RPM\nBug heading - you get +- 10 degrees \nFirst 90 Degrees\nFull power - stay level \n30 degrees bank quickly\nThen Slowly increase pitch to 15 degrees right at 90 degrees\nSecond 90 Degrees\nHold nose at 15 degrees - Requires more back pressure \nSlowly bring bank to 0 right at 180 degrees\n*Airspeed should end around 60 knots - stall speed is 48 clean - stall horn happens around 10 knots above that \n\nHow:\n\nWhy:\n",
           "title": "Chandelles",
           "type": "fill"
         },
@@ -6339,8 +6339,8 @@
               "word": "Steep"
             }
           ],
-          "rawHtml": "<p>Steep Turns</p><p>Altitude: +/- 100 ft</p><p>Entry Speed: 95 Knots +/- 10 Knots</p><p>Bank Angle: 50 ° +/- 5°</p><p>At 30 ° start to increase back pressure and add power</p>",
-          "rawText": "Steep Turns\nAltitude: +/- 100 ft\nEntry Speed: 95 Knots +/- 10 Knots\nBank Angle: 50 ° +/- 5°\nAt 30 ° start to increase back pressure and add power\n",
+          "rawHtml": "<h3>What</h3><p>Steep Turns</p><p>Altitude: +/- 100 ft</p><p>Entry Speed: 95 Knots +/- 10 Knots</p><p>Bank Angle: 50 \u00b0 +/- 5\u00b0</p><p>At 30 \u00b0 start to increase back pressure and add power</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nSteep Turns\nAltitude: +/- 100 ft\nEntry Speed: 95 Knots +/- 10 Knots\nBank Angle: 50 \u00b0 +/- 5\u00b0\nAt 30 \u00b0 start to increase back pressure and add power\n\nHow:\n\nWhy:\n",
           "title": "Steep Turns",
           "type": "fill"
         },
@@ -6384,8 +6384,8 @@
               "word": "heading"
             }
           ],
-          "rawHtml": "<p>What: 3x360 turns while descending and maintaining your distance around a point with wind correction  </p><p><br></p><p>Clean configuration </p><p>80 knots </p><p>Finish no lower than 1500 ft AGL</p><p>Each 360 you should give yourself 1000 ft </p><p>So start at or above 4500 ft AGL</p><p>Have to use less than 60 degree bank</p><p>Airspeed and heading you get +- 10</p><p>Start</p><p>Find a point on the ground and put it under the wheel on your side </p><p>Start into a headwind - so the least steep bank to start - bug heading </p><p>Downwind you make it more steep </p><p>Tail wind is the most steep </p><p>Upwind is mid steep like downwind </p><p>Start power idle </p><p>Let nose come down and start turn </p><p>Use trim for airspeed</p><p>When you finish one 360 smoothly add power to at least green to clear the engine </p><p>Should be a few around 3 seconds to put it in and then a few to take it out </p>",
-          "rawText": "What: 3x360 turns while descending and maintaining your distance around a point with wind correction  \n\nClean configuration \n80 knots \nFinish no lower than 1500 ft AGL\nEach 360 you should give yourself 1000 ft \nSo start at or above 4500 ft AGL\nHave to use less than 60 degree bank\nAirspeed and heading you get +- 10\nStart\nFind a point on the ground and put it under the wheel on your side \nStart into a headwind - so the least steep bank to start - bug heading \nDownwind you make it more steep \nTail wind is the most steep \nUpwind is mid steep like downwind \nStart power idle \nLet nose come down and start turn \nUse trim for airspeed\nWhen you finish one 360 smoothly add power to at least green to clear the engine \nShould be a few around 3 seconds to put it in and then a few to take it out \n",
+          "rawHtml": "<h3>What</h3><p>What: 3x360 turns while descending and maintaining your distance around a point with wind correction  </p><p><br></p><p>Clean configuration </p><p>80 knots </p><p>Finish no lower than 1500 ft AGL</p><p>Each 360 you should give yourself 1000 ft </p><p>So start at or above 4500 ft AGL</p><p>Have to use less than 60 degree bank</p><p>Airspeed and heading you get +- 10</p><p>Start</p><p>Find a point on the ground and put it under the wheel on your side </p><p>Start into a headwind - so the least steep bank to start - bug heading </p><p>Downwind you make it more steep </p><p>Tail wind is the most steep </p><p>Upwind is mid steep like downwind </p><p>Start power idle </p><p>Let nose come down and start turn </p><p>Use trim for airspeed</p><p>When you finish one 360 smoothly add power to at least green to clear the engine </p><p>Should be a few around 3 seconds to put it in and then a few to take it out </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nWhat: 3x360 turns while descending and maintaining your distance around a point with wind correction  \n\nClean configuration \n80 knots \nFinish no lower than 1500 ft AGL\nEach 360 you should give yourself 1000 ft \nSo start at or above 4500 ft AGL\nHave to use less than 60 degree bank\nAirspeed and heading you get +- 10\nStart\nFind a point on the ground and put it under the wheel on your side \nStart into a headwind - so the least steep bank to start - bug heading \nDownwind you make it more steep \nTail wind is the most steep \nUpwind is mid steep like downwind \nStart power idle \nLet nose come down and start turn \nUse trim for airspeed\nWhen you finish one 360 smoothly add power to at least green to clear the engine \nShould be a few around 3 seconds to put it in and then a few to take it out \n\nHow:\n\nWhy:\n",
           "title": "Steep Spiral",
           "type": "fill"
         },
@@ -6421,8 +6421,8 @@
               "word": "idle"
             }
           ],
-          "rawHtml": "<p> \t◊ Never go to full break </p><p>Why: Show the danger of adding too much bank on base to final and stall spins </p><p><br></p><p>Clean configuration</p><p>85 knots </p><p>No lower than 3000 ft AGL</p><p>No airspeed or heading requirements</p><p>Start</p><p>Power idle </p><p>Bank 45 degrees</p><p>Nose up/Hold Altitude to induce stall</p><p>At first indication - Acknowledge it</p><p>Go wings level and max power</p><p>Right rudder on recovery to the right  </p><p>Climb out Vx or Vy</p><p>Level to Cruise</p>",
-          "rawText": " \t◊ Never go to full break \nWhy: Show the danger of adding too much bank on base to final and stall spins \n\nClean configuration\n85 knots \nNo lower than 3000 ft AGL\nNo airspeed or heading requirements\nStart\nPower idle \nBank 45 degrees\nNose up/Hold Altitude to induce stall\nAt first indication - Acknowledge it\nGo wings level and max power\nRight rudder on recovery to the right  \nClimb out Vx or Vy\nLevel to Cruise\n",
+          "rawHtml": "<h3>What</h3><p> \t\u25ca Never go to full break </p><p>Why: Show the danger of adding too much bank on base to final and stall spins </p><p><br></p><p>Clean configuration</p><p>85 knots </p><p>No lower than 3000 ft AGL</p><p>No airspeed or heading requirements</p><p>Start</p><p>Power idle </p><p>Bank 45 degrees</p><p>Nose up/Hold Altitude to induce stall</p><p>At first indication - Acknowledge it</p><p>Go wings level and max power</p><p>Right rudder on recovery to the right  </p><p>Climb out Vx or Vy</p><p>Level to Cruise</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n \t\u25ca Never go to full break \nWhy: Show the danger of adding too much bank on base to final and stall spins \n\nClean configuration\n85 knots \nNo lower than 3000 ft AGL\nNo airspeed or heading requirements\nStart\nPower idle \nBank 45 degrees\nNose up/Hold Altitude to induce stall\nAt first indication - Acknowledge it\nGo wings level and max power\nRight rudder on recovery to the right  \nClimb out Vx or Vy\nLevel to Cruise\n\nHow:\n\nWhy:\n",
           "title": "Accelerated Stall",
           "type": "fill"
         },
@@ -6494,8 +6494,8 @@
               "word": "10"
             }
           ],
-          "rawHtml": "<p>Lazy Eights</p><p>Clean configuration </p><p>Airspeed 105 knots </p><p>Bug heading</p><p>At or above 1500 AGL</p><p>Start</p><p>Bank and pitch Slowly to 15 for the first 45 degrees </p><p>Bank to 30 and pitch to 0 to 90 degrees </p><p>Bank 15 pitch around -10 to 135 degrees </p><p>Bank and pitch to 0 at 180 </p><p>Then to the other side same thing</p><p>At each point need to be +- 10 knots +- 100 ft and +- 10 degrees heading </p><p>Should hit the degrees and pitch slowly right as you hit the degrees should never really be holding an attitude </p><p>Tips </p><p>Around 90 degrees marks make sure you are on top of rudder </p>",
-          "rawText": "Lazy Eights\nClean configuration \nAirspeed 105 knots \nBug heading\nAt or above 1500 AGL\nStart\nBank and pitch Slowly to 15 for the first 45 degrees \nBank to 30 and pitch to 0 to 90 degrees \nBank 15 pitch around -10 to 135 degrees \nBank and pitch to 0 at 180 \nThen to the other side same thing\nAt each point need to be +- 10 knots +- 100 ft and +- 10 degrees heading \nShould hit the degrees and pitch slowly right as you hit the degrees should never really be holding an attitude \nTips \nAround 90 degrees marks make sure you are on top of rudder \n",
+          "rawHtml": "<h3>What</h3><p>Lazy Eights</p><p>Clean configuration </p><p>Airspeed 105 knots </p><p>Bug heading</p><p>At or above 1500 AGL</p><p>Start</p><p>Bank and pitch Slowly to 15 for the first 45 degrees </p><p>Bank to 30 and pitch to 0 to 90 degrees </p><p>Bank 15 pitch around -10 to 135 degrees </p><p>Bank and pitch to 0 at 180 </p><p>Then to the other side same thing</p><p>At each point need to be +- 10 knots +- 100 ft and +- 10 degrees heading </p><p>Should hit the degrees and pitch slowly right as you hit the degrees should never really be holding an attitude </p><p>Tips </p><p>Around 90 degrees marks make sure you are on top of rudder </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nLazy Eights\nClean configuration \nAirspeed 105 knots \nBug heading\nAt or above 1500 AGL\nStart\nBank and pitch Slowly to 15 for the first 45 degrees \nBank to 30 and pitch to 0 to 90 degrees \nBank 15 pitch around -10 to 135 degrees \nBank and pitch to 0 at 180 \nThen to the other side same thing\nAt each point need to be +- 10 knots +- 100 ft and +- 10 degrees heading \nShould hit the degrees and pitch slowly right as you hit the degrees should never really be holding an attitude \nTips \nAround 90 degrees marks make sure you are on top of rudder \n\nHow:\n\nWhy:\n",
           "title": "Lazy Eights",
           "type": "fill"
         },
@@ -6543,8 +6543,8 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p>Eights on Pylons</p><p>Pivotal altitude: Ground speed squared divided by 11.3 + elevation </p><p>Clean configuration </p><p>Doesn’t have the altitude restriction of 1500 AGL</p><p>Start at 2500 MSL</p><p>95 knots </p><p><br></p><p>Find two points </p><p>Get to pivotal altitude </p><p>Position for 45 degrees quartering tailwind </p><p>Bug heading. - entry heading is also exit heading </p><p>Fly until first point is abeam your shoulder</p><p>This has to be done with a crosswind from the points  </p><p>When ground speed goes down pitch goes down and vice versa</p><p>You fly about 5 seconds when you level out </p><p>If the point starts to get in front of your wing you push forward and if it moves back you pull back</p>",
-          "rawText": "Eights on Pylons\nPivotal altitude: Ground speed squared divided by 11.3 + elevation \nClean configuration \nDoesn’t have the altitude restriction of 1500 AGL\nStart at 2500 MSL\n95 knots \n\nFind two points \nGet to pivotal altitude \nPosition for 45 degrees quartering tailwind \nBug heading. - entry heading is also exit heading \nFly until first point is abeam your shoulder\nThis has to be done with a crosswind from the points  \nWhen ground speed goes down pitch goes down and vice versa\nYou fly about 5 seconds when you level out \nIf the point starts to get in front of your wing you push forward and if it moves back you pull back\n",
+          "rawHtml": "<h3>What</h3><p>Eights on Pylons</p><p>Pivotal altitude: Ground speed squared divided by 11.3 + elevation </p><p>Clean configuration </p><p>Doesn\u2019t have the altitude restriction of 1500 AGL</p><p>Start at 2500 MSL</p><p>95 knots </p><p><br></p><p>Find two points </p><p>Get to pivotal altitude </p><p>Position for 45 degrees quartering tailwind </p><p>Bug heading. - entry heading is also exit heading </p><p>Fly until first point is abeam your shoulder</p><p>This has to be done with a crosswind from the points  </p><p>When ground speed goes down pitch goes down and vice versa</p><p>You fly about 5 seconds when you level out </p><p>If the point starts to get in front of your wing you push forward and if it moves back you pull back</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nEights on Pylons\nPivotal altitude: Ground speed squared divided by 11.3 + elevation \nClean configuration \nDoesn\u2019t have the altitude restriction of 1500 AGL\nStart at 2500 MSL\n95 knots \n\nFind two points \nGet to pivotal altitude \nPosition for 45 degrees quartering tailwind \nBug heading. - entry heading is also exit heading \nFly until first point is abeam your shoulder\nThis has to be done with a crosswind from the points  \nWhen ground speed goes down pitch goes down and vice versa\nYou fly about 5 seconds when you level out \nIf the point starts to get in front of your wing you push forward and if it moves back you pull back\n\nHow:\n\nWhy:\n",
           "title": "Eights on Pylons",
           "type": "fill"
         },
@@ -6580,16 +6580,16 @@
               "word": "70"
             }
           ],
-          "rawHtml": "<p>Pattern is the same until abeam the touchdown point then</p><p>Power idle </p><p>Continue downwind and turn base half the normal distance </p><p>When you level make sure you aren’t low </p><p>You want to start final high</p><p><br></p><p>If you have less than 10 total knots of wind in any direction go flaps 10 at power idle </p><p>If more than 10 knots don’t go flaps 10</p><p>Aim for 70 knots don’t force it though let it happen and hold it</p>",
-          "rawText": "Pattern is the same until abeam the touchdown point then\nPower idle \nContinue downwind and turn base half the normal distance \nWhen you level make sure you aren’t low \nYou want to start final high\n\nIf you have less than 10 total knots of wind in any direction go flaps 10 at power idle \nIf more than 10 knots don’t go flaps 10\nAim for 70 knots don’t force it though let it happen and hold it\n",
+          "rawHtml": "<h3>What</h3><p>Pattern is the same until abeam the touchdown point then</p><p>Power idle </p><p>Continue downwind and turn base half the normal distance </p><p>When you level make sure you aren\u2019t low </p><p>You want to start final high</p><p><br></p><p>If you have less than 10 total knots of wind in any direction go flaps 10 at power idle </p><p>If more than 10 knots don\u2019t go flaps 10</p><p>Aim for 70 knots don\u2019t force it though let it happen and hold it</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nPattern is the same until abeam the touchdown point then\nPower idle \nContinue downwind and turn base half the normal distance \nWhen you level make sure you aren\u2019t low \nYou want to start final high\n\nIf you have less than 10 total knots of wind in any direction go flaps 10 at power idle \nIf more than 10 knots don\u2019t go flaps 10\nAim for 70 knots don\u2019t force it though let it happen and hold it\n\nHow:\n\nWhy:\n",
           "title": "Power Off 180",
           "type": "fill"
         },
         {
           "alts": {},
           "hidden": [],
-          "rawHtml": "<p>Above 3000' Density Altitude</p><p>Find best power setting on the ground by going</p><p>Full throttle</p><p>Cruise Lean</p>",
-          "rawText": "Above 3000' Density Altitude\nFind best power setting on the ground by going\nFull throttle\nCruise Lean\n",
+          "rawHtml": "<h3>What</h3><p>Above 3000' Density Altitude</p><p>Find best power setting on the ground by going</p><p>Full throttle</p><p>Cruise Lean</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nAbove 3000' Density Altitude\nFind best power setting on the ground by going\nFull throttle\nCruise Lean\n\nHow:\n\nWhy:\n",
           "title": "Leaning Mixture",
           "type": "fill"
         },
@@ -6637,8 +6637,8 @@
               "word": "7700"
             }
           ],
-          "rawHtml": "<p>A - Airspeed 68 KIAS</p><p>B - Best Spot to land</p><p>C - Checklist - Restart Procedures</p><p>D - Declare | 121.5 7700</p><p>E - Execute </p>",
-          "rawText": "A - Airspeed 68 KIAS\nB - Best Spot to land\nC - Checklist - Restart Procedures\nD - Declare | 121.5 7700\nE - Execute \n",
+          "rawHtml": "<h3>What</h3><p>A - Airspeed 68 KIAS</p><p>B - Best Spot to land</p><p>C - Checklist - Restart Procedures</p><p>D - Declare | 121.5 7700</p><p>E - Execute </p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nA - Airspeed 68 KIAS\nB - Best Spot to land\nC - Checklist - Restart Procedures\nD - Declare | 121.5 7700\nE - Execute \n\nHow:\n\nWhy:\n",
           "title": "Engine Failure ABCs (Cruise)",
           "type": "fill"
         },
@@ -6706,8 +6706,8 @@
               "word": "Auxiliary"
             }
           ],
-          "rawHtml": "<p>1:  Airspeed - 68 KIAS</p><p>2:  Fuel Shutoff - ON (Pushed In)</p><p>3:  Fuel Selector Valve - Both</p><p>4:  Auxiliary Fuel Pump - ON</p><p>5:  Mixture - Rich</p><p>6:  Ignition Switch - Both or Start if Prop completely stopped</p><p>7:  Auxiliary Fuel Pump - OFF unless fuel flow immediately drops to zero again</p>",
-          "rawText": "1:  Airspeed - 68 KIAS\n2:  Fuel Shutoff - ON (Pushed In)\n3:  Fuel Selector Valve - Both\n4:  Auxiliary Fuel Pump - ON\n5:  Mixture - Rich\n6:  Ignition Switch - Both or Start if Prop completely stopped\n7:  Auxiliary Fuel Pump - OFF unless fuel flow immediately drops to zero again\n",
+          "rawHtml": "<h3>What</h3><p>1:  Airspeed - 68 KIAS</p><p>2:  Fuel Shutoff - ON (Pushed In)</p><p>3:  Fuel Selector Valve - Both</p><p>4:  Auxiliary Fuel Pump - ON</p><p>5:  Mixture - Rich</p><p>6:  Ignition Switch - Both or Start if Prop completely stopped</p><p>7:  Auxiliary Fuel Pump - OFF unless fuel flow immediately drops to zero again</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n1:  Airspeed - 68 KIAS\n2:  Fuel Shutoff - ON (Pushed In)\n3:  Fuel Selector Valve - Both\n4:  Auxiliary Fuel Pump - ON\n5:  Mixture - Rich\n6:  Ignition Switch - Both or Start if Prop completely stopped\n7:  Auxiliary Fuel Pump - OFF unless fuel flow immediately drops to zero again\n\nHow:\n\nWhy:\n",
           "title": "Engine Failure Restart Procedures",
           "type": "fill"
         },
@@ -6783,8 +6783,8 @@
               "word": "Out"
             }
           ],
-          "rawHtml": "<p>1:  Mixture - Out</p><p>2:  Fuel Shutoff Valve - Pull Out</p><p>3:  Auxiliary Fuel Pump - OFF</p><p>4:  Master Switch - OFF</p><p>5:  Cabin Heat and Air - OFF</p><p>5:  Airspeed - 100 - 105 KIAS</p><p>7:  Land</p>",
-          "rawText": "1:  Mixture - Out\n2:  Fuel Shutoff Valve - Pull Out\n3:  Auxiliary Fuel Pump - OFF\n4:  Master Switch - OFF\n5:  Cabin Heat and Air - OFF\n5:  Airspeed - 100 - 105 KIAS\n7:  Land\n",
+          "rawHtml": "<h3>What</h3><p>1:  Mixture - Out</p><p>2:  Fuel Shutoff Valve - Pull Out</p><p>3:  Auxiliary Fuel Pump - OFF</p><p>4:  Master Switch - OFF</p><p>5:  Cabin Heat and Air - OFF</p><p>5:  Airspeed - 100 - 105 KIAS</p><p>7:  Land</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n1:  Mixture - Out\n2:  Fuel Shutoff Valve - Pull Out\n3:  Auxiliary Fuel Pump - OFF\n4:  Master Switch - OFF\n5:  Cabin Heat and Air - OFF\n5:  Airspeed - 100 - 105 KIAS\n7:  Land\n\nHow:\n\nWhy:\n",
           "title": "Engine Fire (In Flight)",
           "type": "fill"
         },
@@ -6860,8 +6860,8 @@
               "word": "OFF"
             }
           ],
-          "rawHtml": "<p>1:  Master Switch - OFF</p><p>2:  Cabin Heat and Air - OFF</p><p>3:  Fire Extinguisher - Use</p><p>4:  Avionics Master - OFF</p><p>5:  All Other Switches - OFF</p>",
-          "rawText": "1:  Master Switch - OFF\n2:  Cabin Heat and Air - OFF\n3:  Fire Extinguisher - Use\n4:  Avionics Master - OFF\n5:  All Other Switches - OFF\n",
+          "rawHtml": "<h3>What</h3><p>1:  Master Switch - OFF</p><p>2:  Cabin Heat and Air - OFF</p><p>3:  Fire Extinguisher - Use</p><p>4:  Avionics Master - OFF</p><p>5:  All Other Switches - OFF</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n1:  Master Switch - OFF\n2:  Cabin Heat and Air - OFF\n3:  Fire Extinguisher - Use\n4:  Avionics Master - OFF\n5:  All Other Switches - OFF\n\nHow:\n\nWhy:\n",
           "title": "Electrical Fire (In Flight)",
           "type": "fill"
         },
@@ -6889,8 +6889,8 @@
               "word": "up"
             }
           ],
-          "rawHtml": "<p>1:  All Lights Off </p><p>2:  Perform a Sideslip bringing the wing on fire up to keep it away from fuel tanks</p><p>3:  Land ASAP</p>",
-          "rawText": "1:  All Lights Off \n2:  Perform a Sideslip bringing the wing on fire up to keep it away from fuel tanks\n3:  Land ASAP\n",
+          "rawHtml": "<h3>What</h3><p>1:  All Lights Off </p><p>2:  Perform a Sideslip bringing the wing on fire up to keep it away from fuel tanks</p><p>3:  Land ASAP</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\n1:  All Lights Off \n2:  Perform a Sideslip bringing the wing on fire up to keep it away from fuel tanks\n3:  Land ASAP\n\nHow:\n\nWhy:\n",
           "title": "Wing Fire",
           "type": "fill"
         }
@@ -6929,7 +6929,7 @@
               "letter": "S"
             }
           ],
-          "rawText": "",
+          "rawText": "What:\n\nHow:\n\nWhy:\n",
           "type": "acronym",
           "hidden": [],
           "alts": {}
@@ -6937,7 +6937,7 @@
         {
           "type": "fill",
           "title": "Test",
-          "rawText": ""
+          "rawText": "What:\n\nHow:\n\nWhy:\n"
         }
       ]
     },
@@ -6956,8 +6956,8 @@
               "occ": 1
             }
           ],
-          "rawHtml": "<p>Testing tester 123 </p><p>Test me Please pretty</p><p>hello test</p>",
-          "rawText": "Testing tester 123 \nTest me Please pretty\nhello test\n",
+          "rawHtml": "<h3>What</h3><p>Testing tester 123 </p><p>Test me Please pretty</p><p>hello test</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nTesting tester 123 \nTest me Please pretty\nhello test\n\nHow:\n\nWhy:\n",
           "title": "Test Question #1",
           "type": "fill"
         },
@@ -6978,8 +6978,8 @@
               "reveal": true
             }
           ],
-          "rawHtml": "<p>This is the Twooo test question.</p><p><strong style=\"color: rgb(0, 102, 204);\">Get </strong>Tested﻿</p><p>dgdfw</p>",
-          "rawText": "This is the Twooo test question.\nGet Tested﻿\ndgdfw\n",
+          "rawHtml": "<h3>What</h3><p>This is the Twooo test question.</p><p><strong style=\"color: rgb(0, 102, 204);\">Get </strong>Tested\ufeff</p><p>dgdfw</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nThis is the Twooo test question.\nGet Tested\ufeff\ndgdfw\n\nHow:\n\nWhy:\n",
           "title": "Test Qestion #2",
           "type": "fill"
         },
@@ -7004,8 +7004,8 @@
               "reveal": true
             }
           ],
-          "rawHtml": "<p>Did this new save thing work?</p><p>Take Two?</p>",
-          "rawText": "Did this new save thing work?\nTake Two?\n",
+          "rawHtml": "<h3>What</h3><p>Did this new save thing work?</p><p>Take Two?</p><h3>How</h3><p></p><h3>Why</h3><p></p>",
+          "rawText": "What:\nDid this new save thing work?\nTake Two?\n\nHow:\n\nWhy:\n",
           "title": "Test    #3",
           "type": "fill"
         },
@@ -7028,14 +7028,14 @@
           ],
           "definitions": [],
           "arrows": [],
-          "rawHtml": "<p><br></p>",
+          "rawHtml": "<h3>What</h3><p><br></p><h3>How</h3><p></p><h3>Why</h3><p></p>",
           "imgWidth": 1039,
           "imgHeight": 480
         },
         {
           "type": "fill",
           "title": "How do you do?",
-          "rawText": ""
+          "rawText": "What:\n\nHow:\n\nWhy:\n"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add "What," "How," and "Why" headings to every quiz entry's stored HTML and plain text
- preserve the original question content inside the new What sections while leaving placeholders for How and Why

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf72b698b883238c20e5faaf1508e6