### PR TITLE
Improve edit preview spacing and mobile quiz readability

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -267,10 +267,10 @@
       line-height: 1.4;
     }
     .word {
-      display: inline;
+      display: inline-block;
       white-space: pre-wrap;
       word-break: break-word;
-      margin: 2px;
+      margin: 3px 5px 3px 0;
       padding: 4px 6px;
       border-radius: 4px;
       transition: background .2s;
@@ -600,6 +600,23 @@
       #quizArea,
       #quizContent {
         font-size: 1rem;
+      }
+      #quizArea {
+        padding: 18px 12px;
+      }
+      #quizContent {
+        padding: 18px 14px;
+      }
+      .question-section-card {
+        margin: 12px 0;
+        padding: 14px 14px 16px 18px;
+        border-radius: 14px;
+      }
+      .question-section-card::after {
+        left: 8px;
+        top: 14px;
+        bottom: 14px;
+        width: 4px;
       }
       #quizContent .blank input,
       .blank input {


### PR DESCRIPTION
## Summary
- add a little more breathing room around edit-mode word tokens so they are easier to tap individually
- tighten quiz-mode padding on small screens so questions fit better without changing text size

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0493ce0808323ac28a22791f2ff54