### PR TITLE
Increase question text size and improve WHW spacing

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -468,7 +468,7 @@
       display: flex;
       flex-direction: column;
       gap: 0.65rem;
-      font-size: 1rem;
+      font-size: 1.1rem;
       line-height: 1.6;
       color: #34495e;
     }
@@ -536,6 +536,25 @@
     }
     body.mobile #editorArea .question-section-card.whw-section .question-section-body {
       gap: 0.75rem;
+    }
+
+    #editorArea .question-section-card.whw-section .question-section-body.empty {
+      position: relative;
+      padding: 0.95rem 0 0.65rem;
+      min-height: 2.6rem;
+    }
+    #editorArea .question-section-card.whw-section .question-section-body.empty::before {
+      content: '';
+      display: block;
+      height: 1.2rem;
+      border-radius: 14px;
+      background: linear-gradient(90deg, rgba(26,188,156,0.18), rgba(52,152,219,0.18));
+      opacity: 0.65;
+    }
+    #editorArea .question-section-card.whw-section .question-section-body.empty::after {
+      content: '';
+      display: block;
+      height: 0.9rem;
     }
 
     #quizArea .question-section-heading.whw-heading {


### PR DESCRIPTION
## Summary
- enlarge the default desktop question text for better readability
- add edit-mode styling so empty What/How/Why sections show attractive breathing room between headings

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d48247e3c08323ab4b75dd0b3255d9