### PR TITLE
Adjust section hover overlay transparency

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -403,7 +403,7 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background: linear-gradient(135deg, rgba(26,188,156,0.12), rgba(52,152,219,0.12));
+      background: linear-gradient(135deg, rgba(26,188,156,0.08), rgba(52,152,219,0.08));
       opacity: 0;
       transition: opacity 0.3s ease;
       pointer-events: none;


### PR DESCRIPTION
## Summary
- soften the hover overlay gradient for question sections by lowering the green tint opacity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4895a5a3c83238b93bc1ee9901a20