### PR TITLE
Ensure Siri voices appear in the TTS dropdown

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -3231,11 +3231,19 @@
 
       const getVoiceKey = voice => {
         if (!voice) return '';
-        const { voiceURI, name = '', lang = '' } = voice;
-        if (voiceURI && typeof voiceURI === 'string') {
+        const voiceURI = typeof voice.voiceURI === 'string' ? voice.voiceURI : '';
+        const name = typeof voice.name === 'string' ? voice.name : '';
+        const lang = typeof voice.lang === 'string' ? voice.lang : '';
+        if (voiceURI && name) {
+          return `${voiceURI}:::${name}`;
+        }
+        if (voiceURI) {
           return voiceURI;
         }
-        return `${name}:::${lang}`;
+        if (name || lang) {
+          return `${name}:::${lang}`;
+        }
+        return '';
       };
 
       function nodeMarkedForSpeechSkip(node) {


### PR DESCRIPTION
## Summary
- adjust the voice key generator to include the voice name when possible so distinct Siri voices are not collapsed during deduplication

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de9aa34ca483239cd03113d32303ec