### PR TITLE
Filter TTS voices to English

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -3749,6 +3749,8 @@
             uniqueVoices.push(voice);
           }
         });
+        const englishVoices = uniqueVoices.filter(voice => /^en/i.test(voice.lang || ''));
+        const filteredVoices = englishVoices.length ? englishVoices : uniqueVoices;
         const qualityPatterns = [
           /neural/i,
           /natural/i,
@@ -3809,7 +3811,7 @@
           return /^en([-_])?us\b/.test(lang);
         };
         const isEnglishVoice = voice => /^en/i.test(voice.lang || '');
-        availableTtsVoices = sortVoices(uniqueVoices);
+        availableTtsVoices = sortVoices(filteredVoices);
         if (!availableTtsVoices.length) {
           updateVoiceControlsVisibility(false);
           updateTtsHint();


### PR DESCRIPTION
## Summary
- filter the collected speech synthesis voices down to English locales before ranking them
- fall back to the full list if no English voices are present, preserving compatibility

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb7ebf8b88323b7057af6b0655d77