### PR TITLE
Prevent TTS from reading section labels

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -6486,6 +6486,7 @@
 
           const badge = document.createElement('span');
           badge.className = 'question-section-badge';
+          badge.setAttribute('data-tts-skip', 'true');
           const badgeText = processed < 10 ? `0${processed}` : String(processed);
           badge.textContent = badgeText;
           badge.setAttribute('aria-label', `Section ${processed}`);
@@ -6503,6 +6504,10 @@
           const keyword = heading.dataset.sectionKeyword || detectSectionKeyword(heading.textContent || '');
           if (keyword) {
             heading.dataset.sectionKeyword = keyword;
+            const headingText = (heading.textContent || '').trim().toLowerCase();
+            if (headingText === keyword) {
+              heading.setAttribute('data-tts-skip', 'true');
+            }
           }
           if (['what', 'how', 'why'].includes(keyword)) {
             card.classList.add('whw-section', `whw-${keyword}`);


### PR DESCRIPTION
## Summary
- mark question section badges so custom text-to-speech skips the visual numbering
- ignore WHW-only headings when building the spoken text to avoid reading WHAT/HOW/WHY labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decd94af608323995464cab8309fe8