### PR TITLE
Normalize button styling across browsers

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -66,6 +66,35 @@
       display: flex;
     }
 
+    /* —— Form Control Normalization —— */
+    button,
+    input,
+    select,
+    textarea {
+      font-family: inherit;
+      font-size: 0.95rem;
+      line-height: 1.2;
+      color: inherit;
+    }
+    button,
+    input[type="button"],
+    input[type="submit"],
+    input[type="reset"] {
+      -webkit-appearance: none;
+      appearance: none;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      padding: 8px 12px;
+      background-color: #fdfdfd;
+    }
+    button:focus-visible,
+    input[type="button"]:focus-visible,
+    input[type="submit"]:focus-visible,
+    input[type="reset"]:focus-visible {
+      outline: 2px solid #2980b9;
+      outline-offset: 2px;
+    }
+
     /* —— Sidebar —— */
     #sidebar {
       width: 240px;
@@ -84,6 +113,8 @@
 
     /* QuestionControls buttons base styling */
     #questionControls button {
+      padding: 10px 12px;
+      line-height: 1.25;
       border-top: none;
       border-right: none;
       border-bottom: none;


### PR DESCRIPTION
## Summary
- normalize button and form control defaults so Safari sizing is reused across browsers
- tune question controls padding and line-height for consistent measurements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e46dc9548323bece14d47502aef4