### PR TITLE
Reduce default button sizing

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -72,7 +72,7 @@
     select,
     textarea {
       font-family: inherit;
-      font-size: 0.95rem;
+      font-size: 0.9rem;
       line-height: 1.2;
       color: inherit;
     }
@@ -84,7 +84,7 @@
       appearance: none;
       border: 1px solid transparent;
       border-radius: 6px;
-      padding: 8px 12px;
+      padding: 6px 10px;
       background-color: #fdfdfd;
     }
     button:focus-visible,
@@ -113,7 +113,7 @@
 
     /* QuestionControls buttons base styling */
     #questionControls button {
-      padding: 10px 12px;
+      padding: 8px 10px;
       line-height: 1.25;
       border-top: none;
       border-right: none;


### PR DESCRIPTION
## Summary
- reduce the base button font size and padding to make the default buttons more compact
- tighten the question controls button padding to match the smaller default buttons

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e3ea2997bc83238016307a70a3b6f8