### PR TITLE
Adjust question control button layout

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -1204,10 +1204,10 @@
       <ul id="sections" class="nav"></ul>
     </div>
     <div id="questionControls" style="position: sticky; bottom: 0; background: #2c3e50; padding: 8px; display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px;">
-      <button id="addFillBtn" style="padding: 4px 12px; white-space: normal; overflow-wrap: break-word; text-align: center; line-height: 1.2em;">+ Fill-In</button>
-      <button id="addLabelBtn" style="padding: 4px 12px; white-space: normal; overflow-wrap: break-word; text-align: center; line-height: 1.2em;">+ Diagram</button>
-      <button id="addAcronymBtn" style="padding: 4px 12px; white-space: normal; overflow-wrap: break-word; text-align: center; line-height: 1.2em;">+ Acronym</button>
-      <button id="toggleDeleteBtn" style="padding: 4px 12px; white-space: normal; overflow-wrap: break-word; text-align: center; line-height: 1.2em;">🗑️ Delete</button>
+      <button id="addFillBtn" style="padding: 2px 10px; white-space: nowrap; overflow: hidden; text-align: center; line-height: 1.1; display: inline-flex; align-items: center; justify-content: center; gap: 4px;">+ Fill-In</button>
+      <button id="addLabelBtn" style="padding: 2px 10px; white-space: nowrap; overflow: hidden; text-align: center; line-height: 1.1; display: inline-flex; align-items: center; justify-content: center; gap: 4px;">+ Diagram</button>
+      <button id="addAcronymBtn" style="padding: 2px 10px; white-space: nowrap; overflow: hidden; text-align: center; line-height: 1.1; display: inline-flex; align-items: center; justify-content: center; gap: 4px;">+ Acronym</button>
+      <button id="toggleDeleteBtn" style="padding: 2px 10px; white-space: nowrap; overflow: hidden; text-align: center; line-height: 1.1; display: inline-flex; align-items: center; justify-content: center; gap: 4px;">🗑️ Delete</button>
       <input type="file" id="labelImageInput" accept="image/*" style="display:none;">
     </div>
   </div>


### PR DESCRIPTION
## Summary
- reduce padding on the add question and delete buttons so they take up less vertical space
- force the button contents to stay on a single line so the icon and text remain side by side

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3ecc0040c8323816d94e5b7d3973f