### PR TITLE
fix: replace smart quotes that broke page loading

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -9368,7 +9368,7 @@
               saveProgress();
             }
           }
-        // Now load that section’s data
+        // Now load that section's data
         let sec = data.folders[currentFolder].sections[currentSection];
         ensureSectionImages(currentFolder, sec);
         if (!sec.rawHtml && sec.rawText) {
@@ -10305,10 +10305,10 @@
           if (active && active.dataset && active.dataset.answer) {
             target = active;
           } else {
-            const blankInputs = Array.from(document.querySelectorAll(‘#quizContent input.blank-input’));
-            const acronymInputs = Array.from(document.querySelectorAll(‘#quizContent input.acronym-input’));
-            target = blankInputs.find(i => i.dataset.answer && !i.classList.contains(‘correct’)) ||
-                     acronymInputs.find(i => i.dataset.answer && !i.classList.contains(‘correct’)) ||
+            const blankInputs = Array.from(document.querySelectorAll('#quizContent input.blank-input'));
+            const acronymInputs = Array.from(document.querySelectorAll('#quizContent input.acronym-input'));
+            target = blankInputs.find(i => i.dataset.answer && !i.classList.contains('correct')) ||
+                     acronymInputs.find(i => i.dataset.answer && !i.classList.contains('correct')) ||
                      null;
           }
         }
@@ -10318,24 +10318,24 @@
           sessionHintsUsed++;
           updateSessionStats();
 
-          const answers = JSON.parse(target.getAttribute(‘data-answer’));
-          const correct = answers[0] || ‘’;
+          const answers = JSON.parse(target.getAttribute('data-answer'));
+          const correct = answers[0] || '';
           const prevWidth = target.style.width;
           target.value = correct;
-          target.classList.add(‘showing-hint’);
+          target.classList.add('showing-hint');
 
           if (target.dataset.label) {
             // Picture‑label blanks can shrink when empty; temporarily size to reveal hint fully
-            target.style.width = correct.length + 1 + ‘ch’;
+            target.style.width = correct.length + 1 + 'ch';
           }
 
           target.focus();
           setTimeout(() => {
-            // Clear only if user hasn’t typed something else
+            // Clear only if user hasn't typed something else
             if (target.value.trim().toLowerCase() === correct.toLowerCase()) {
-              target.value = ‘’;
+              target.value = '';
             }
-            target.classList.remove(‘showing-hint’);
+            target.classList.remove('showing-hint');
             if (target.dataset.label) {
               target.style.width = prevWidth;
             }


### PR DESCRIPTION
## Summary

- The previous improvements commit introduced curly/typographic single quotes (`'` / `'`) in JavaScript string literals inside the hint button handler
- These are not valid JS string delimiters, causing a `SyntaxError` that prevented the entire script from running — which is why the page got stuck on "Loading folders..."
- This PR replaces all 22 affected smart quotes with standard ASCII single quotes (`'`)

## Test plan
- [ ] Page loads normally (folders appear)
- [ ] Hint button works in quiz mode
- [ ] All new features from previous PR still work (dark mode, toasts, stats bar, completion overlay)

https://claude.ai/code/session_01VKfNYmd57Zz1ci6nPwiWxk