### PR TITLE
fix: crash on load when folder has no sections array

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -4188,7 +4188,7 @@
           });
           const secList = document.createElement('ul');
           secList.style.display = mobileOpenFolders.has(idx) ? 'block' : 'none';
-          f.sections.forEach((s, si) => {
+          (f.sections || []).forEach((s, si) => {
             const title = s.title || s.acronym || (s.rawText && s.rawText.split('\n')[0]) || '';
             const description = (s.type === 'acronym' && s.description && s.description.trim())
               ? s.description.trim()
@@ -4379,7 +4379,7 @@
         folderList.style.display = 'none';
         results.style.display = 'block';
         data.folders.forEach((f, fi) => {
-          f.sections.forEach((s, si) => {
+          (f.sections || []).forEach((s, si) => {
             const title = s.title || s.acronym || (s.rawText && s.rawText.split('\n')[0]) || '';
             const description = (s.type === 'acronym' && s.description && s.description.trim())
               ? s.description.trim()
@@ -4975,7 +4975,7 @@
       };
 
       (data.folders || []).forEach(folder => {
-        if (!folder.sections) return;
+        if (!Array.isArray(folder.sections)) { folder.sections = []; return; }
         folder.sections.forEach(normalizeSection);
       });
 


### PR DESCRIPTION
## Bug

Opening the app showed `Error: undefined is not an object (evaluating 'f.sections.forEach')` and the ⋯ menu stopped responding entirely.

## Root cause

Two related issues:

1. **Data normalization** — when folders are loaded from storage, the code did `if (!folder.sections) return`, silently skipping any folder missing a `sections` array instead of initializing it. So a folder saved without `sections` would load in a broken state.

2. **No defensive guard** — `buildMobileFolderList()` and `handleMobileSearch()` called `f.sections.forEach(...)` directly. One broken folder crashes the entire render, which also prevents all event listeners (including the ⋯ button) from being set up.

## Fix

- Changed normalization to `if (!Array.isArray(folder.sections)) { folder.sections = []; return }` so missing sections are always initialized on load.
- Changed all `f.sections.forEach(` calls to `(f.sections || []).forEach(` as a defensive fallback so a single bad folder can't take down the whole app.

## Test plan

- [ ] Add a folder via the ⋯ menu, close and reopen — no crash
- [ ] ⋯ button responds after reloading
- [ ] Existing folders and questions unaffected

https://claude.ai/code/session_01VKfNYmd57Zz1ci6nPwiWxk