### PR TITLE
Fix: adding question to new mobile folder does nothing

### DIFF
--- a/QuizMaker.html
+++ b/QuizMaker.html
@@ -7927,6 +7927,9 @@
 
       function enterEdit(){
         stopSpeech({ clearStart: true });
+        if (document.body.classList.contains('mobile')) {
+          document.body.classList.add('quiz-active');
+        }
         editorArea.style.display = 'block';
         quizArea.style.display = 'none';
         altContainer.style.display = 'none';


### PR DESCRIPTION
enterEdit() now ensures quiz-active is set on mobile so #main is
visible when the editor opens. Without it, newly-created folders
had no quiz-active class, so the edit screen was hidden.

https://claude.ai/code/session_01VKfNYmd57Zz1ci6nPwiWxk